### PR TITLE
More improvements to the Grammars API.

### DIFF
--- a/src/FarkleNeo/DebuggerTypeProxies.cs
+++ b/src/FarkleNeo/DebuggerTypeProxies.cs
@@ -30,3 +30,45 @@ internal class DfaEdgesProxy<TChar> : FlatCollectionProxy<DfaEdge<TChar>, DfaSta
 {
     public DfaEdgesProxy(DfaState<TChar>.EdgeCollection collection) : base(collection) { }
 }
+
+[DebuggerDisplay("{Value,nq}", Name = "{Name,nq}")]
+internal readonly struct NameValuePair
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public readonly string Name, Value;
+
+    public NameValuePair(string name, string value)
+    {
+        Name = name;
+        Value = value;
+    }
+}
+
+internal sealed class LrStateProxy
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    private readonly NameValuePair[] _actions;
+
+    public LrStateProxy(LrState state)
+    {
+        _actions = new NameValuePair[state.Actions.Count + state.EndOfFileActions.Count + state.Gotos.Count];
+
+        Grammar grammar = state.Grammar;
+        int i = 0;
+        foreach (var action in state.Actions)
+        {
+            TokenSymbol terminal = grammar.GetTokenSymbol(action.Key);
+            _actions[i++] = new NameValuePair(terminal.ToString(), action.Value.ToString(grammar));
+        }
+        foreach (var action in state.EndOfFileActions)
+        {
+            _actions[i++] = new NameValuePair("(EOF)", action.ToString(grammar));
+        }
+        foreach (var @goto in state.Gotos)
+        {
+            Nonterminal nonterminal = grammar.GetNonterminal(@goto.Key);
+            _actions[i++] = new NameValuePair(nonterminal.ToString(), $"Goto state {@goto.Value}");
+        }
+        Debug.Assert(i == _actions.Length);
+    }
+}

--- a/src/FarkleNeo/DebuggerTypeProxies.cs
+++ b/src/FarkleNeo/DebuggerTypeProxies.cs
@@ -1,0 +1,32 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+global using Farkle.DebuggerTypeProxies;
+using Farkle.Grammars;
+using Farkle.Grammars.StateMachines;
+using System.Diagnostics;
+
+namespace Farkle.DebuggerTypeProxies;
+
+internal class FlatCollectionProxy<T, TCollection> where TCollection : IEnumerable<T>
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    public readonly T[] _items;
+
+    public FlatCollectionProxy(TCollection list) => _items = list.ToArray();
+}
+
+internal class DfaProxy<TChar> : FlatCollectionProxy<DfaState<TChar>, Dfa<TChar>>
+{
+    public DfaProxy(Dfa<TChar> dfa) : base(dfa) { }
+}
+
+internal class DfaAcceptSymbolsProxy<TChar> : FlatCollectionProxy<TokenSymbolHandle, DfaState<TChar>.AcceptSymbolCollection>
+{
+    public DfaAcceptSymbolsProxy(DfaState<TChar>.AcceptSymbolCollection collection) : base(collection) { }
+}
+
+internal class DfaEdgesProxy<TChar> : FlatCollectionProxy<DfaEdge<TChar>, DfaState<TChar>.EdgeCollection>
+{
+    public DfaEdgesProxy(DfaState<TChar>.EdgeCollection collection) : base(collection) { }
+}

--- a/src/FarkleNeo/Grammars/EntityHandle.cs
+++ b/src/FarkleNeo/Grammars/EntityHandle.cs
@@ -67,6 +67,11 @@ public readonly struct EntityHandle : IEquatable<EntityHandle>
     public override int GetHashCode() => _valueAndKind.GetHashCode();
 
     /// <summary>
+    /// Returns a string describing the the <see cref="EntityHandle"/>.
+    /// </summary>
+    public override string ToString() => HasValue ? $"{Kind} {TableIndex + 1}" : "<null>";
+
+    /// <summary>
     /// Checks if two <see cref="EntityHandle"/>s are pointing to the same table row.
     /// </summary>
     /// <param name="left">The first handle.</param>

--- a/src/FarkleNeo/Grammars/GrammarInfo.cs
+++ b/src/FarkleNeo/Grammars/GrammarInfo.cs
@@ -1,12 +1,15 @@
 // Copyright © Theodore Tsirpanis and Contributors.
 // SPDX-License-Identifier: MIT
 
+using System.Diagnostics;
+
 namespace Farkle.Grammars;
 
 /// <summary>
 /// Contains general information about a <see cref="Grammar"/>.
 /// </summary>
 /// <seealso cref="Grammar.GrammarInfo"/>
+[DebuggerDisplay("Name = {_grammar.GetString(Name)}; StartSymbol = {_grammar.GetNonterminal(StartSymbol)}; Attributes = {Attributes}")]
 public readonly struct GrammarInfo
 {
     private readonly Grammar _grammar { get; }

--- a/src/FarkleNeo/Grammars/Group.cs
+++ b/src/FarkleNeo/Grammars/Group.cs
@@ -130,4 +130,9 @@ public readonly struct Group
             return new(_grammar, offset, (int)(nextOffset - offset));
         }
     }
+
+    /// <summary>
+    /// Returns a string describing the the <see cref="Group"/>.
+    /// </summary>
+    public override string ToString() => _grammar.GetString(Name);
 }

--- a/src/FarkleNeo/Grammars/GroupCollection.cs
+++ b/src/FarkleNeo/Grammars/GroupCollection.cs
@@ -11,6 +11,7 @@ namespace Farkle.Grammars;
 /// </summary>
 /// <seealso cref="Grammar.Groups"/>
 [DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(FlatCollectionProxy<Group, GroupCollection>))]
 public readonly struct GroupCollection : IReadOnlyCollection<Group>
 {
     private readonly Grammar _grammar;

--- a/src/FarkleNeo/Grammars/GroupCollection.cs
+++ b/src/FarkleNeo/Grammars/GroupCollection.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using System.Collections;
+using System.Diagnostics;
 
 namespace Farkle.Grammars;
 
@@ -9,6 +10,7 @@ namespace Farkle.Grammars;
 /// Contains the <see cref="Group"/>s of a <see cref="Grammar"/>.
 /// </summary>
 /// <seealso cref="Grammar.Groups"/>
+[DebuggerDisplay("Count = {Count}")]
 public readonly struct GroupCollection : IReadOnlyCollection<Group>
 {
     private readonly Grammar _grammar;

--- a/src/FarkleNeo/Grammars/GroupNestingCollection.cs
+++ b/src/FarkleNeo/Grammars/GroupNestingCollection.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using System.Collections;
+using System.Diagnostics;
 
 namespace Farkle.Grammars;
 
@@ -9,6 +10,7 @@ namespace Farkle.Grammars;
 /// Contains the <see cref="Group"/>s that can be nested inside a <see cref="Group"/>.
 /// </summary>
 /// <seealso cref="Group.Nesting"/>
+[DebuggerDisplay("Count = {Count}")]
 public readonly struct GroupNestingCollection : IReadOnlyCollection<Group>
 {
     private readonly Grammar _grammar;

--- a/src/FarkleNeo/Grammars/GroupNestingCollection.cs
+++ b/src/FarkleNeo/Grammars/GroupNestingCollection.cs
@@ -11,6 +11,7 @@ namespace Farkle.Grammars;
 /// </summary>
 /// <seealso cref="Group.Nesting"/>
 [DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(FlatCollectionProxy<Group, GroupCollection>))]
 public readonly struct GroupNestingCollection : IReadOnlyCollection<Group>
 {
     private readonly Grammar _grammar;

--- a/src/FarkleNeo/Grammars/Nonterminal.cs
+++ b/src/FarkleNeo/Grammars/Nonterminal.cs
@@ -83,4 +83,9 @@ public readonly struct Nonterminal
             return new(_grammar, offset, (int)(nextOffset - offset));
         }
     }
+
+    /// <summary>
+    /// Returns a string describing the the <see cref="Nonterminal"/>.
+    /// </summary>
+    public override string ToString() => $"<{_grammar.GetString(Name)}>";
 }

--- a/src/FarkleNeo/Grammars/NonterminalCollection.cs
+++ b/src/FarkleNeo/Grammars/NonterminalCollection.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using System.Collections;
+using System.Diagnostics;
 
 namespace Farkle.Grammars;
 
@@ -9,6 +10,7 @@ namespace Farkle.Grammars;
 /// Contains the <see cref="Nonterminal"/>s of a <see cref="Grammar"/>.
 /// </summary>
 /// <seealso cref="Grammar.Nonterminals"/>
+[DebuggerDisplay("Count = {Count}")]
 public readonly struct NonterminalCollection : IReadOnlyCollection<Nonterminal>
 {
     private readonly Grammar _grammar;

--- a/src/FarkleNeo/Grammars/NonterminalHandle.cs
+++ b/src/FarkleNeo/Grammars/NonterminalHandle.cs
@@ -53,6 +53,11 @@ public readonly struct NonterminalHandle : IEquatable<NonterminalHandle>
     public override int GetHashCode() => TableIndex.GetHashCode();
 
     /// <summary>
+    /// Returns a string describing the the <see cref="NonterminalHandle"/>.
+    /// </summary>
+    public override string ToString() => HasValue ? Value.ToString() : "<null>";
+
+    /// <summary>
     /// Checks if two <see cref="NonterminalHandle"/>s are pointing to the same row.
     /// </summary>
     /// <param name="left">The first handle.</param>

--- a/src/FarkleNeo/Grammars/Production.cs
+++ b/src/FarkleNeo/Grammars/Production.cs
@@ -63,9 +63,9 @@ public readonly struct Production
     }
 
     /// <summary>
-    /// A sequence of the <see cref="Production"/>'s members.
+    /// A list of the <see cref="Production"/>'s members.
     /// </summary>
-    public ProductionMemberCollection Members
+    public ProductionMemberList Members
     {
         get
         {

--- a/src/FarkleNeo/Grammars/Production.cs
+++ b/src/FarkleNeo/Grammars/Production.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using System.Diagnostics;
+using System.Text;
 
 namespace Farkle.Grammars;
 
@@ -73,5 +74,30 @@ public readonly struct Production
             (uint offset, uint nextOffset) = GetMemberBounds(_grammar.GrammarFile, in _grammar.GrammarTables);
             return new(_grammar, offset, (int)(nextOffset - offset));
         }
+    }
+
+    /// <summary>
+    /// Returns a string describing the the <see cref="Production"/>.
+    /// </summary>
+    public override string ToString()
+    {
+        StringBuilder sb = new();
+
+        sb.Append(_grammar.GetNonterminal(Head));
+        sb.Append(" ::=");
+        foreach (EntityHandle member in Members)
+        {
+            sb.Append(' ');
+            if (member.IsTokenSymbol)
+            {
+                sb.Append(_grammar.GetTokenSymbol((TokenSymbolHandle)member));
+            }
+            else
+            {
+                sb.Append(_grammar.GetNonterminal((NonterminalHandle)member));
+            }
+        }
+
+        return sb.ToString();
     }
 }

--- a/src/FarkleNeo/Grammars/ProductionCollection.cs
+++ b/src/FarkleNeo/Grammars/ProductionCollection.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using System.Collections;
+using System.Diagnostics;
 
 namespace Farkle.Grammars;
 
@@ -9,6 +10,7 @@ namespace Farkle.Grammars;
 /// Contains the members of a <see cref="Production"/>.
 /// </summary>
 /// <seealso cref="Production.Members"/>
+[DebuggerDisplay("Count = {Count}")]
 public readonly struct ProductionCollection : IReadOnlyCollection<Production>
 {
     private readonly Grammar _grammar;

--- a/src/FarkleNeo/Grammars/ProductionCollection.cs
+++ b/src/FarkleNeo/Grammars/ProductionCollection.cs
@@ -11,6 +11,7 @@ namespace Farkle.Grammars;
 /// </summary>
 /// <seealso cref="Production.Members"/>
 [DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(FlatCollectionProxy<Production, ProductionCollection>))]
 public readonly struct ProductionCollection : IReadOnlyCollection<Production>
 {
     private readonly Grammar _grammar;

--- a/src/FarkleNeo/Grammars/ProductionHandle.cs
+++ b/src/FarkleNeo/Grammars/ProductionHandle.cs
@@ -53,6 +53,11 @@ public readonly struct ProductionHandle : IEquatable<ProductionHandle>
     public override int GetHashCode() => TableIndex.GetHashCode();
 
     /// <summary>
+    /// Returns a string describing the the <see cref="ProductionHandle"/>.
+    /// </summary>
+    public override string ToString() => HasValue ? Value.ToString() : "<null>";
+
+    /// <summary>
     /// Checks if two <see cref="ProductionHandle"/>s are pointing to the same row.
     /// </summary>
     /// <param name="left">The first handle.</param>

--- a/src/FarkleNeo/Grammars/ProductionMemberCollection.cs
+++ b/src/FarkleNeo/Grammars/ProductionMemberCollection.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using System.Collections;
+using System.Diagnostics;
 
 namespace Farkle.Grammars;
 
@@ -9,6 +10,7 @@ namespace Farkle.Grammars;
 /// Contains the members of a <see cref="Production"/>.
 /// </summary>
 /// <seealso cref="Production.Members"/>
+[DebuggerDisplay("Count = {Count}")]
 public readonly struct ProductionMemberCollection : IReadOnlyCollection<EntityHandle>
 {
     private readonly Grammar _grammar;

--- a/src/FarkleNeo/Grammars/ProductionMemberList.cs
+++ b/src/FarkleNeo/Grammars/ProductionMemberList.cs
@@ -11,6 +11,7 @@ namespace Farkle.Grammars;
 /// </summary>
 /// <seealso cref="Production.Members"/>
 [DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(FlatCollectionProxy<EntityHandle, ProductionMemberList>))]
 public readonly struct ProductionMemberList : IReadOnlyList<EntityHandle>
 {
     private readonly Grammar _grammar;

--- a/src/FarkleNeo/Grammars/ProductionMemberList.cs
+++ b/src/FarkleNeo/Grammars/ProductionMemberList.cs
@@ -11,7 +11,7 @@ namespace Farkle.Grammars;
 /// </summary>
 /// <seealso cref="Production.Members"/>
 [DebuggerDisplay("Count = {Count}")]
-public readonly struct ProductionMemberCollection : IReadOnlyCollection<EntityHandle>
+public readonly struct ProductionMemberList : IReadOnlyList<EntityHandle>
 {
     private readonly Grammar _grammar;
 
@@ -20,7 +20,24 @@ public readonly struct ProductionMemberCollection : IReadOnlyCollection<EntityHa
     /// <inheritdoc/>
     public int Count { get; }
 
-    internal ProductionMemberCollection(Grammar grammar, uint offset, int count)
+    /// <summary>
+    /// Gets the production member at the specified index.
+    /// </summary>
+    /// <param name="index">The index of the production member.</param>
+    public EntityHandle this[int index]
+    {
+        get
+        {
+            if ((uint)index >= (uint)Count)
+            {
+                ThrowHelpers.ThrowArgumentOutOfRangeException(nameof(index));
+            }
+
+            return _grammar.GrammarTables.GetProductionMemberMember(_grammar.GrammarFile, (uint)index + _offset);
+        }
+    }
+
+    internal ProductionMemberList(Grammar grammar, uint offset, int count)
     {
         _grammar = grammar;
         _offset = offset;
@@ -36,14 +53,14 @@ public readonly struct ProductionMemberCollection : IReadOnlyCollection<EntityHa
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     /// <summary>
-    /// Used to enumerate a <see cref="ProductionMemberCollection"/>.
+    /// Used to enumerate a <see cref="ProductionMemberList"/>.
     /// </summary>
     public struct Enumerator : IEnumerator<EntityHandle>
     {
-        private readonly ProductionMemberCollection _collection;
+        private readonly ProductionMemberList _collection;
         private int _currentIndex = -1;
 
-        internal Enumerator(ProductionMemberCollection collection)
+        internal Enumerator(ProductionMemberList collection)
         {
             _collection = collection;
         }
@@ -57,8 +74,7 @@ public readonly struct ProductionMemberCollection : IReadOnlyCollection<EntityHa
                 {
                     ThrowHelpers.ThrowInvalidOperationException();
                 }
-                Grammar grammar = _collection._grammar;
-                return grammar.GrammarTables.GetProductionMemberMember(grammar.GrammarFile, (uint)(_collection._offset + _currentIndex));
+                return _collection[_currentIndex];
             }
         }
 

--- a/src/FarkleNeo/Grammars/StateMachines/Dfa.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/Dfa.cs
@@ -18,7 +18,7 @@ namespace Farkle.Grammars.StateMachines;
 /// </remarks>
 /// <typeparam name="TChar">The type of characters the DFA accepts.
 /// Typically it is <see cref="char"/> or <see cref="byte"/>.</typeparam>
-[DebuggerDisplay("Count = {Count}")]
+[DebuggerDisplay("Count = {Count}; HasConflicts = {HasConflicts}}")]
 public abstract class Dfa<TChar> : IReadOnlyList<DfaState<TChar>>
 {
     internal Dfa(int stateCount, bool hasConflicts)

--- a/src/FarkleNeo/Grammars/StateMachines/Dfa.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/Dfa.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 namespace Farkle.Grammars.StateMachines;
 
 /// <summary>
-/// Represents a deterministic finite automaton (DFA) stored in a <see cref="Grammar"/>.
+/// Represents a deterministic finite automaton (DFA) stored in a <see cref="Grammars.Grammar"/>.
 /// It is used by tokenizers to break the input stream into a series of tokens.
 /// </summary>
 /// <remarks>
@@ -26,6 +26,8 @@ public abstract class Dfa<TChar> : IReadOnlyList<DfaState<TChar>>
         Count = stateCount;
         HasConflicts = hasConflicts;
     }
+
+    internal abstract Grammar Grammar { get; }
 
     internal abstract (int Offset, int Count) GetAcceptSymbolBounds(int state);
 

--- a/src/FarkleNeo/Grammars/StateMachines/Dfa.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/Dfa.cs
@@ -19,6 +19,7 @@ namespace Farkle.Grammars.StateMachines;
 /// <typeparam name="TChar">The type of characters the DFA accepts.
 /// Typically it is <see cref="char"/> or <see cref="byte"/>.</typeparam>
 [DebuggerDisplay("Count = {Count}; HasConflicts = {HasConflicts}}")]
+[DebuggerTypeProxy(typeof(DfaProxy<>))]
 public abstract class Dfa<TChar> : IReadOnlyList<DfaState<TChar>>
 {
     internal Dfa(int stateCount, bool hasConflicts)

--- a/src/FarkleNeo/Grammars/StateMachines/Dfa.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/Dfa.cs
@@ -40,20 +40,6 @@ public abstract class Dfa<TChar> : IReadOnlyList<DfaState<TChar>>
 
     internal abstract DfaEdge<TChar> GetEdgeAt(int index);
 
-    internal virtual TokenSymbolHandle GetSingleAcceptSymbol(int state)
-    {
-        switch (GetAcceptSymbolBounds(state))
-        {
-            case (int offset, 1):
-                return GetAcceptSymbolAt(offset);
-            case (_, 0):
-                return default;
-            default:
-                ThrowHelpers.ThrowInvalidOperationException("The DFA state has more than one accept symbol.");
-                return default;
-        }
-    }
-
     internal virtual bool StateHasConflicts(int state) => GetAcceptSymbolBounds(state).Count > 1;
 
     /// <summary>
@@ -97,11 +83,23 @@ public abstract class Dfa<TChar> : IReadOnlyList<DfaState<TChar>>
     }
 
     /// <summary>
+    /// Gets the accept symbol of a state on a <see cref="Dfa{TChar}"/>
+    /// with no conflicting accept symbols.
+    /// </summary>
+    /// <param name="state">The state's index.</param>
+    /// <returns>A <see cref="TokenSymbolHandle"/> pointing to the state's accept symbol,
+    /// or having no value if the state is not an accept state.</returns>
+    /// <exception cref="NotSupportedException">The DFA <see cref="HasConflicts"/>.</exception>
+    /// <remarks>This method is intended to be used by parsers.</remarks>
+    public abstract TokenSymbolHandle GetAcceptSymbol(int state);
+
+    /// <summary>
     /// Performs a transition from one state to another, based on the current character.
     /// </summary>
     /// <param name="state">The index of the current state.</param>
     /// <param name="c">The current character in the input stream.</param>
     /// <returns>The index of the next state or -1 if such state does not exist.</returns>
+    /// <remarks>This method is intended to be used by parsers.</remarks>
     public abstract int NextState(int state, TChar c);
 
     /// <summary>

--- a/src/FarkleNeo/Grammars/StateMachines/Dfa.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/Dfa.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using System.Collections;
+using System.Diagnostics;
 
 namespace Farkle.Grammars.StateMachines;
 
@@ -17,6 +18,7 @@ namespace Farkle.Grammars.StateMachines;
 /// </remarks>
 /// <typeparam name="TChar">The type of characters the DFA accepts.
 /// Typically it is <see cref="char"/> or <see cref="byte"/>.</typeparam>
+[DebuggerDisplay("Count = {Count}")]
 public abstract class Dfa<TChar> : IReadOnlyList<DfaState<TChar>>
 {
     internal Dfa(int stateCount, bool hasConflicts)

--- a/src/FarkleNeo/Grammars/StateMachines/DfaEdge.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/DfaEdge.cs
@@ -1,6 +1,8 @@
 // Copyright © Theodore Tsirpanis and Contributors.
 // SPDX-License-Identifier: MIT
 
+using System.Diagnostics;
+
 namespace Farkle.Grammars.StateMachines;
 
 /// <summary>
@@ -8,6 +10,7 @@ namespace Farkle.Grammars.StateMachines;
 /// </summary>
 /// <typeparam name="TChar">The type of characters the DFA accepts.
 /// Typically it is <see cref="char"/> or <see cref="byte"/>.</typeparam>
+[DebuggerDisplay("{DebuggerDisplay(),nq}")]
 public readonly struct DfaEdge<TChar> : IEquatable<DfaEdge<TChar>>
 {
     /// <summary>
@@ -36,6 +39,45 @@ public readonly struct DfaEdge<TChar> : IEquatable<DfaEdge<TChar>>
         KeyFrom = keyFrom;
         KeyTo = keyTo;
         Target = target;
+    }
+
+    private string DebuggerDisplay()
+    {
+        string target = Target < 0 ? "<fail>" : Target.ToString();
+        if (EqualityComparer<TChar>.Default.Equals(KeyFrom, KeyTo))
+        {
+            return $"{Format(KeyFrom)} -> {target}";
+        }
+        return $"[{Format(KeyFrom)},{Format(KeyTo)}] -> {target}";
+
+        static string Format(TChar c)
+        {
+            if (c is char c2)
+            {
+                return c2 switch
+                {
+                    '\0' => "'\\0'",
+                    '\a' => "'\\a'",
+                    '\b' => "'\\b'",
+                    '\f' => "'\\f'",
+                    '\n' => "'\\n'",
+                    '\r' => "'\\r'",
+                    '\t' => "'\\t'",
+                    '\v' => "'\\v'",
+                    '\'' => "'\\''",
+                    '"' => "'\"'",
+                    '\\' => "'\\\\'",
+                    _ => c2 < 32 || c2 > 126 ? $"'\\u{(int)c2:X4}'" : $"'{c2}'"
+                };
+            }
+
+            if (c is byte b)
+            {
+                return $"0x{b:X2}";
+            }
+
+            return $"'{c}'";
+        }
     }
 
     /// <inheritdoc/>

--- a/src/FarkleNeo/Grammars/StateMachines/DfaEdge.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/DfaEdge.cs
@@ -50,34 +50,35 @@ public readonly struct DfaEdge<TChar> : IEquatable<DfaEdge<TChar>>
         }
         return $"[{Format(KeyFrom)},{Format(KeyTo)}] -> {target}";
 
-        static string Format(TChar c)
+    }
+
+    internal static string Format(TChar c)
+    {
+        if (c is char c2)
         {
-            if (c is char c2)
+            return c2 switch
             {
-                return c2 switch
-                {
-                    '\0' => "'\\0'",
-                    '\a' => "'\\a'",
-                    '\b' => "'\\b'",
-                    '\f' => "'\\f'",
-                    '\n' => "'\\n'",
-                    '\r' => "'\\r'",
-                    '\t' => "'\\t'",
-                    '\v' => "'\\v'",
-                    '\'' => "'\\''",
-                    '"' => "'\"'",
-                    '\\' => "'\\\\'",
-                    _ => c2 < 32 || c2 > 126 ? $"'\\u{(int)c2:X4}'" : $"'{c2}'"
-                };
-            }
-
-            if (c is byte b)
-            {
-                return $"0x{b:X2}";
-            }
-
-            return $"'{c}'";
+                '\0' => "'\\0'",
+                '\a' => "'\\a'",
+                '\b' => "'\\b'",
+                '\f' => "'\\f'",
+                '\n' => "'\\n'",
+                '\r' => "'\\r'",
+                '\t' => "'\\t'",
+                '\v' => "'\\v'",
+                '\'' => "'\\''",
+                '"' => "'\"'",
+                '\\' => "'\\\\'",
+                _ => c2 < 32 || c2 > 126 ? $"'\\u{(int)c2:X4}'" : $"'{c2}'"
+            };
         }
+
+        if (c is byte b)
+        {
+            return $"0x{b:X2}";
+        }
+
+        return $"'{c}'";
     }
 
     /// <inheritdoc/>

--- a/src/FarkleNeo/Grammars/StateMachines/DfaEdge.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/DfaEdge.cs
@@ -21,10 +21,10 @@ public readonly struct DfaEdge<TChar> : IEquatable<DfaEdge<TChar>>
     public TChar KeyTo { get; }
 
     /// <summary>
-    /// The index of the target DFA state, starting from 1.
+    /// The index of the target DFA state, starting from 0.
     /// </summary>
     /// <remarks>
-    /// A value of 0 indicates that following this edge should stop the tokenizer.
+    /// A negative value indicates that following this edge should stop the tokenizer.
     /// </remarks>
     public int Target { get; }
 

--- a/src/FarkleNeo/Grammars/StateMachines/DfaImplementationBase.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/DfaImplementationBase.cs
@@ -9,8 +9,6 @@ namespace Farkle.Grammars.StateMachines;
 
 internal unsafe abstract class DfaImplementationBase<TChar, TState, TEdge> : Dfa<TChar> where TChar : unmanaged, IComparable<TChar>
 {
-    protected readonly Grammar _grammar;
-
     private readonly int _edgeCount;
 
     public required int FirstEdgeBase { get; init; }
@@ -28,7 +26,7 @@ internal unsafe abstract class DfaImplementationBase<TChar, TState, TEdge> : Dfa
         Debug.Assert(StateMachineUtilities.GetDfaStateTargetIndexSize(stateCount) == sizeof(TState));
         Debug.Assert(StateMachineUtilities.GetIndexSize(edgeCount) == sizeof(TEdge));
 
-        _grammar = grammar;
+        Grammar = grammar;
         _edgeCount = edgeCount;
     }
 
@@ -42,7 +40,7 @@ internal unsafe abstract class DfaImplementationBase<TChar, TState, TEdge> : Dfa
     {
         ValidateStateIndex(state);
 
-        ReadOnlySpan<byte> grammarFile = _grammar.GrammarFile;
+        ReadOnlySpan<byte> grammarFile = Grammar.GrammarFile;
 
         int edgeOffset = ReadFirstEdge(grammarFile, state);
         int edgeLength = (state != Count - 1 ? ReadFirstEdge(grammarFile, state + 1) : _edgeCount) - edgeOffset;
@@ -73,6 +71,8 @@ internal unsafe abstract class DfaImplementationBase<TChar, TState, TEdge> : Dfa
         return -1;
     }
 
+    internal sealed override Grammar Grammar { get; }
+
     internal sealed override int GetDefaultTransition(int state)
     {
         ValidateStateIndex(state);
@@ -82,14 +82,14 @@ internal unsafe abstract class DfaImplementationBase<TChar, TState, TEdge> : Dfa
             return -1;
         }
 
-        return ReadState(_grammar.GrammarFile, DefaultTransitionBase + state * sizeof(TState));
+        return ReadState(Grammar.GrammarFile, DefaultTransitionBase + state * sizeof(TState));
     }
 
     internal sealed override (int Offset, int Count) GetEdgeBounds(int state)
     {
         ValidateStateIndex(state);
 
-        ReadOnlySpan<byte> grammarFile = _grammar.GrammarFile;
+        ReadOnlySpan<byte> grammarFile = Grammar.GrammarFile;
 
         int edgeOffset = ReadFirstEdge(grammarFile, state);
         int nextEdgeOffset = state != Count - 1 ? ReadFirstEdge(grammarFile, state + 1) : _edgeCount;
@@ -104,7 +104,7 @@ internal unsafe abstract class DfaImplementationBase<TChar, TState, TEdge> : Dfa
             ThrowHelpers.ThrowArgumentOutOfRangeException(nameof(index));
         }
 
-        ReadOnlySpan<byte> grammarFile = _grammar.GrammarFile;
+        ReadOnlySpan<byte> grammarFile = Grammar.GrammarFile;
 
         TChar cFrom = StateMachineUtilities.Read<TChar>(grammarFile, RangeFromBase + index * sizeof(char));
         TChar cTo = StateMachineUtilities.Read<TChar>(grammarFile, RangeToBase + index * sizeof(char));

--- a/src/FarkleNeo/Grammars/StateMachines/DfaState.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/DfaState.cs
@@ -36,23 +36,8 @@ public readonly struct DfaState<TChar>
     }
 
     /// <summary>
-    /// The <see cref="DfaState{TChar}"/>'s accept symbol, if it exists.
-    /// </summary>
-    /// <returns>A <see cref="TokenSymbolHandle"/> pointing to the state's accept symbol.
-    /// Its <see cref="TokenSymbolHandle.HasValue"/> property will be set to <see langword="false"/>
-    /// if the state is not an accept state.</returns>
-    /// <exception cref="InvalidOperationException">The state has more than one accept symbols.
-    /// This can be checked with the <see cref="HasConflicts"/> property.</exception>
-    /// <remarks>
-    /// To improve performance, parsers should use this property instead of <see cref="AcceptSymbols"/>.
-    /// </remarks>
-    /// <seealso cref="HasConflicts"/>
-    public TokenSymbolHandle AcceptSymbol => _dfa.GetSingleAcceptSymbol(StateIndex);
-
-    /// <summary>
     /// The <see cref="DfaState{TChar}"/>'s possible accept symbols.
     /// </summary>
-    /// <seealso cref="AcceptSymbol"/>
     /// <seealso cref="HasConflicts"/>
     public AcceptSymbolCollection AcceptSymbols
     {

--- a/src/FarkleNeo/Grammars/StateMachines/DfaState.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/DfaState.cs
@@ -17,9 +17,12 @@ namespace Farkle.Grammars.StateMachines;
 /// use the <see cref="Dfa{TChar}.NextState"/> function instead.
 /// </remarks>
 [DebuggerDisplay("{DebuggerDisplay(),nq}")]
+[DebuggerTypeProxy(typeof(DfaStateProxy<>))]
 public readonly struct DfaState<TChar>
 {
     private readonly Dfa<TChar> _dfa;
+
+    internal Grammar Grammar => _dfa.Grammar;
 
     /// <summary>
     /// The index of this <see cref="DfaState{TChar}"/>, starting from 0.
@@ -108,6 +111,7 @@ public readonly struct DfaState<TChar>
     /// <summary>
     /// Contains the edges of a <see cref="DfaState{TChar}"/>.
     /// </summary>
+    [DebuggerTypeProxy(typeof(DfaEdgesProxy<>))]
     public readonly struct EdgeCollection : IReadOnlyCollection<DfaEdge<TChar>>
     {
         private readonly Dfa<TChar> _dfa;
@@ -183,6 +187,7 @@ public readonly struct DfaState<TChar>
     /// <summary>
     /// Contains the accept symbols of a <see cref="DfaState{TChar}"/>.
     /// </summary>
+    [DebuggerTypeProxy(typeof(DfaAcceptSymbolsProxy<>))]
     public readonly struct AcceptSymbolCollection : IReadOnlyCollection<TokenSymbolHandle>
     {
         private readonly Dfa<TChar> _dfa;

--- a/src/FarkleNeo/Grammars/StateMachines/DfaState.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/DfaState.cs
@@ -86,10 +86,6 @@ public readonly struct DfaState<TChar>
     /// <summary>
     /// Whether the <see cref="DfaState{TChar}"/> has more than one possible accept symbol.
     /// </summary>
-    /// <remarks>
-    /// Accessing the <see cref="AcceptSymbol"/> property while this property
-    /// has a value of <see langword="true"/> will cause an exception.
-    /// </remarks>
     /// <seealso cref="Dfa{TChar}.HasConflicts"/>
     public bool HasConflicts => _dfa.StateHasConflicts(StateIndex);
 

--- a/src/FarkleNeo/Grammars/StateMachines/DfaState.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/DfaState.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 using System.Collections;
+using System.Diagnostics;
+using System.Text;
 
 namespace Farkle.Grammars.StateMachines;
 
@@ -14,6 +16,7 @@ namespace Farkle.Grammars.StateMachines;
 /// APIs of this type are intended for presentation purposes. To match text against a DFA,
 /// use the <see cref="Dfa{TChar}.NextState"/> function instead.
 /// </remarks>
+[DebuggerDisplay("{DebuggerDisplay(),nq}")]
 public readonly struct DfaState<TChar>
 {
     private readonly Dfa<TChar> _dfa;
@@ -55,6 +58,24 @@ public readonly struct DfaState<TChar>
             (int offset, int count) = _dfa.GetAcceptSymbolBounds(StateIndex);
             return new(_dfa, offset, count);
         }
+    }
+
+    private string DebuggerDisplay()
+    {
+        var sb = new StringBuilder();
+
+        sb.Append($"{Edges.Count} edges");
+        switch (AcceptSymbols.Count)
+        {
+            case 1:
+                sb.Append(", accept");
+                break;
+            case > 1:
+                sb.Append($", accept({AcceptSymbols.Count})");
+                break;
+        }
+
+        return sb.ToString();
     }
 
     /// <summary>

--- a/src/FarkleNeo/Grammars/StateMachines/DfaState.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/DfaState.cs
@@ -140,7 +140,7 @@ public readonly struct DfaState<TChar>
         {
             private readonly EdgeCollection _collection;
 
-            private int _currentIndex;
+            private int _currentIndex = -1;
 
             internal Enumerator(EdgeCollection collection)
             {
@@ -215,7 +215,7 @@ public readonly struct DfaState<TChar>
         {
             private readonly AcceptSymbolCollection _collection;
 
-            private int _currentIndex;
+            private int _currentIndex = -1;
 
             internal Enumerator(AcceptSymbolCollection collection)
             {

--- a/src/FarkleNeo/Grammars/StateMachines/DfaWithConflicts.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/DfaWithConflicts.cs
@@ -67,7 +67,7 @@ internal unsafe sealed class DfaWithConflicts<TChar, TState, TEdge, TTokenSymbol
     {
         ValidateStateIndex(state);
 
-        ReadOnlySpan<byte> grammarFile = _grammar.GrammarFile;
+        ReadOnlySpan<byte> grammarFile = Grammar.GrammarFile;
         int firstAccept = ReadFirstAccept(grammarFile, state);
         int nextFirstAccept = state != Count - 1 ? ReadFirstAccept(grammarFile, state + 1) : _acceptCount;
         return (firstAccept,  nextFirstAccept - firstAccept);
@@ -79,6 +79,6 @@ internal unsafe sealed class DfaWithConflicts<TChar, TState, TEdge, TTokenSymbol
         {
             ThrowHelpers.ThrowArgumentOutOfRangeException(nameof(index));
         }
-        return new(_grammar.GrammarFile.ReadUIntVariableSize<TTokenSymbol>(AcceptBase + index * sizeof(TTokenSymbol)));
+        return new(Grammar.GrammarFile.ReadUIntVariableSize<TTokenSymbol>(AcceptBase + index * sizeof(TTokenSymbol)));
     }
 }

--- a/src/FarkleNeo/Grammars/StateMachines/DfaWithConflicts.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/DfaWithConflicts.cs
@@ -81,4 +81,7 @@ internal unsafe sealed class DfaWithConflicts<TChar, TState, TEdge, TTokenSymbol
         }
         return new(Grammar.GrammarFile.ReadUIntVariableSize<TTokenSymbol>(AcceptBase + index * sizeof(TTokenSymbol)));
     }
+
+    public override TokenSymbolHandle GetAcceptSymbol(int state) =>
+        throw new NotSupportedException("This method is not supported for DFAs with conflicts.");
 }

--- a/src/FarkleNeo/Grammars/StateMachines/DfaWithoutConflicts.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/DfaWithoutConflicts.cs
@@ -67,7 +67,7 @@ internal unsafe sealed class DfaWithoutConflicts<TChar, TState, TEdge, TTokenSym
     internal override TokenSymbolHandle GetSingleAcceptSymbol(int state)
     {
         ValidateStateIndex(state);
-        return new(_grammar.GrammarFile.ReadUIntVariableSize<TTokenSymbol>(AcceptBase + state * sizeof(TTokenSymbol)));
+        return new(Grammar.GrammarFile.ReadUIntVariableSize<TTokenSymbol>(AcceptBase + state * sizeof(TTokenSymbol)));
     }
 
     internal override bool StateHasConflicts(int state) => false;

--- a/src/FarkleNeo/Grammars/StateMachines/DfaWithoutConflicts.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/DfaWithoutConflicts.cs
@@ -54,7 +54,7 @@ internal unsafe sealed class DfaWithoutConflicts<TChar, TState, TEdge, TTokenSym
     {
         ValidateStateIndex(state);
 
-        if (GetSingleAcceptSymbol(state).HasValue)
+        if (GetAcceptSymbol(state).HasValue)
         {
             return (state, 1);
         }
@@ -62,9 +62,9 @@ internal unsafe sealed class DfaWithoutConflicts<TChar, TState, TEdge, TTokenSym
         return (0, 0);
     }
 
-    internal override TokenSymbolHandle GetAcceptSymbolAt(int index) => GetSingleAcceptSymbol(index);
+    internal override TokenSymbolHandle GetAcceptSymbolAt(int index) => GetAcceptSymbol(index);
 
-    internal override TokenSymbolHandle GetSingleAcceptSymbol(int state)
+    public override TokenSymbolHandle GetAcceptSymbol(int state)
     {
         ValidateStateIndex(state);
         return new(Grammar.GrammarFile.ReadUIntVariableSize<TTokenSymbol>(AcceptBase + state * sizeof(TTokenSymbol)));

--- a/src/FarkleNeo/Grammars/StateMachines/LrAction.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrAction.cs
@@ -6,7 +6,7 @@ namespace Farkle.Grammars.StateMachines;
 /// <summary>
 /// Specifies what an LR parser will do if it encounters a terminal.
 /// </summary>
-public readonly struct LrTerminalAction : IEquatable<LrTerminalAction>
+public readonly struct LrAction : IEquatable<LrAction>
 {
     internal int Value { get; }
 
@@ -17,22 +17,22 @@ public readonly struct LrTerminalAction : IEquatable<LrTerminalAction>
         _ => sizeof(int)
     };
 
-    internal LrTerminalAction(int value) => Value = value;
+    internal LrAction(int value) => Value = value;
 
     /// <summary>
-    /// An <see cref="LrTerminalAction"/> that will cause a syntax error.
+    /// An <see cref="LrAction"/> that will cause a syntax error.
     /// </summary>
     /// <seealso cref="IsError"/>
-    public static LrTerminalAction Error => default;
+    public static LrAction Error => default;
 
     /// <summary>
-    /// Creates an <see cref="LrTerminalAction"/> that will shift to the specified state.
+    /// Creates an <see cref="LrAction"/> that will shift to the specified state.
     /// </summary>
     /// <param name="state">The state's number, starting from zero.</param>
     /// <exception cref="ArgumentOutOfRangeException">
     /// <paramref name="state"/> is negative.</exception>
     /// <seealso cref="IsReduce"/>
-    public static LrTerminalAction CreateShift(int state)
+    public static LrAction CreateShift(int state)
     {
         if (state < 0)
         {
@@ -42,13 +42,13 @@ public readonly struct LrTerminalAction : IEquatable<LrTerminalAction>
     }
 
     /// <summary>
-    /// Creates an <see cref="LrTerminalAction"/> that will reduce the specified <see cref="ProductionHandle"/>.
+    /// Creates an <see cref="LrAction"/> that will reduce the specified <see cref="ProductionHandle"/>.
     /// </summary>
     /// <param name="production">The production to reuse.</param>
     /// <exception cref="ArgumentNullException"><paramref name="production"/>'s
     /// <see cref="ProductionHandle.HasValue"/> property is <see langword="false"/>.</exception>
     /// <seealso cref="IsReduce"/>
-    public static LrTerminalAction CreateReduce(ProductionHandle production)
+    public static LrAction CreateReduce(ProductionHandle production)
     {
         if (!production.HasValue)
         {
@@ -58,25 +58,25 @@ public readonly struct LrTerminalAction : IEquatable<LrTerminalAction>
     }
 
     /// <summary>
-    /// Whether this <see cref="LrTerminalAction"/> will cause a syntax error.
+    /// Whether this <see cref="LrAction"/> will cause a syntax error.
     /// </summary>
     /// <seealso cref="Error"/>
     public bool IsError => Value == 0;
 
     /// <summary>
-    /// Whether this <see cref="LrTerminalAction"/> will shift to another state.
+    /// Whether this <see cref="LrAction"/> will shift to another state.
     /// </summary>
     /// <seealso cref="CreateShift"/>
     public bool IsShift => Value > 0;
 
     /// <summary>
-    /// Whether this <see cref="LrTerminalAction"/> will reduce a production.
+    /// Whether this <see cref="LrAction"/> will reduce a production.
     /// </summary>
     /// <seealso cref="CreateReduce"/>
     public bool IsReduce => Value < 0;
 
     /// <summary>
-    /// The state this <see cref="LrTerminalAction"/> will shift to.
+    /// The state this <see cref="LrAction"/> will shift to.
     /// </summary>
     /// <exception cref="InvalidOperationException">The <see cref="IsShift"/>
     /// property is <see langword="false"/>.</exception>
@@ -93,7 +93,7 @@ public readonly struct LrTerminalAction : IEquatable<LrTerminalAction>
     }
 
     /// <summary>
-    /// The production this <see cref="LrTerminalAction"/> will reduce.
+    /// The production this <see cref="LrAction"/> will reduce.
     /// </summary>
     /// <exception cref="InvalidOperationException">The <see cref="IsReduce"/>
     /// property is <see langword="false"/>.</exception>
@@ -110,10 +110,10 @@ public readonly struct LrTerminalAction : IEquatable<LrTerminalAction>
     }
 
     /// <inheritdoc/>
-    public override bool Equals(object? other) => other is LrTerminalAction x && Equals(x);
+    public override bool Equals(object? other) => other is LrAction x && Equals(x);
 
     /// <inheritdoc/>
-    public bool Equals(LrTerminalAction other) => Value == other.Value;
+    public bool Equals(LrAction other) => Value == other.Value;
 
     /// <inheritdoc/>
     public override int GetHashCode() => Value;
@@ -150,16 +150,16 @@ public readonly struct LrTerminalAction : IEquatable<LrTerminalAction>
     }
 
     /// <summary>
-    /// Checks two <see cref="LrTerminalAction"/>s for equality.
+    /// Checks two <see cref="LrAction"/>s for equality.
     /// </summary>
     /// <param name="left">The first action.</param>
     /// <param name="right">The second action.</param>
-    public static bool operator ==(LrTerminalAction left, LrTerminalAction right) => left.Equals(right);
+    public static bool operator ==(LrAction left, LrAction right) => left.Equals(right);
 
     /// <summary>
-    /// Checks two <see cref="LrTerminalAction"/>s for inequality.
+    /// Checks two <see cref="LrAction"/>s for inequality.
     /// </summary>
     /// <param name="left">The first action.</param>
     /// <param name="right">The second action.</param>
-    public static bool operator !=(LrTerminalAction left, LrTerminalAction right) => !(left==right);
+    public static bool operator !=(LrAction left, LrAction right) => !(left==right);
 }

--- a/src/FarkleNeo/Grammars/StateMachines/LrEndOfFileAction.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrEndOfFileAction.cs
@@ -107,6 +107,21 @@ public readonly struct LrEndOfFileAction : IEquatable<LrEndOfFileAction>
         return "Error";
     }
 
+    internal string ToString(Grammar grammar)
+    {
+        if (IsReduce)
+        {
+            return $"Reduce production {grammar.GetProduction(ReduceProduction)}";
+        }
+
+        if (IsAccept)
+        {
+            return "Accept";
+        }
+
+        return "Error";
+    }
+
     /// <summary>
     /// Checks two <see cref="LrEndOfFileAction"/>s for equality.
     /// </summary>

--- a/src/FarkleNeo/Grammars/StateMachines/LrImplementationBase.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrImplementationBase.cs
@@ -38,7 +38,7 @@ internal unsafe abstract class LrImplementationBase<TStateIndex, TActionIndex, T
         GotoCount = gotoCount;
     }
 
-    protected LrTerminalAction ReadAction(ReadOnlySpan<byte> grammarFile, int index) =>
+    protected LrAction ReadAction(ReadOnlySpan<byte> grammarFile, int index) =>
         new(grammarFile.ReadIntVariableSize<TAction>(ActionBase + index * sizeof(TAction)));
 
     protected int ReadFirstAction(ReadOnlySpan<byte> grammarFile, int state) =>
@@ -67,7 +67,7 @@ internal unsafe abstract class LrImplementationBase<TStateIndex, TActionIndex, T
         return (actionOffset, nextActionOffset - actionOffset);
     }
 
-    internal sealed override KeyValuePair<TokenSymbolHandle, LrTerminalAction> GetActionAt(int index)
+    internal sealed override KeyValuePair<TokenSymbolHandle, LrAction> GetActionAt(int index)
     {
         if ((uint)index >= (uint)ActionCount)
         {
@@ -77,7 +77,7 @@ internal unsafe abstract class LrImplementationBase<TStateIndex, TActionIndex, T
         ReadOnlySpan<byte> grammarFile = Grammar.GrammarFile;
 
         TokenSymbolHandle terminal = new(ReadUIntVariableSizeFromArray<TTokenSymbol>(grammarFile, ActionTerminalBase, index));
-        LrTerminalAction action = ReadAction(grammarFile, index);
+        LrAction action = ReadAction(grammarFile, index);
 
         return new(terminal, action);
     }

--- a/src/FarkleNeo/Grammars/StateMachines/LrImplementationBase.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrImplementationBase.cs
@@ -3,7 +3,6 @@
 
 using Farkle.Buffers;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Farkle.Grammars.StateMachines;
@@ -12,8 +11,6 @@ internal unsafe abstract class LrImplementationBase<TStateIndex, TActionIndex, T
     where TTokenSymbol : unmanaged, IComparable<TTokenSymbol>
     where TNonterminal : unmanaged, IComparable<TNonterminal>
 {
-    protected Grammar Grammar { get; }
-
     protected int ActionCount { get; }
 
     protected int GotoCount { get; }
@@ -55,6 +52,8 @@ internal unsafe abstract class LrImplementationBase<TStateIndex, TActionIndex, T
 
     protected static uint ReadUIntVariableSizeFromArray<T>(ReadOnlySpan<byte> grammarFile, int @base, int index) =>
         grammarFile.ReadUIntVariableSize<T>(@base + index * sizeof(T));
+
+    internal sealed override Grammar Grammar { get; }
 
     internal sealed override (int Offset, int Count) GetActionBounds(int state)
     {

--- a/src/FarkleNeo/Grammars/StateMachines/LrState.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrState.cs
@@ -33,7 +33,7 @@ public readonly struct LrState
 
     /// <summary>
     /// The terminals the <see cref="LrState"/> accepts, along
-    /// with their respective <see cref="LrTerminalAction"/>.
+    /// with their respective <see cref="LrAction"/>.
     /// </summary>
     public ActionCollection Actions => new(_lr, StateIndex);
 
@@ -55,10 +55,10 @@ public readonly struct LrState
 
     /// <summary>
     /// Contains the terminals an <see cref="LrState"/> accepts,
-    /// along with their respective <see cref="LrTerminalAction"/>.
+    /// along with their respective <see cref="LrAction"/>.
     /// </summary>
-    [DebuggerTypeProxy(typeof(FlatCollectionProxy<KeyValuePair<TokenSymbolHandle, LrTerminalAction>, ActionCollection>))]
-    public readonly struct ActionCollection : IReadOnlyCollection<KeyValuePair<TokenSymbolHandle, LrTerminalAction>>
+    [DebuggerTypeProxy(typeof(FlatCollectionProxy<KeyValuePair<TokenSymbolHandle, LrAction>, ActionCollection>))]
+    public readonly struct ActionCollection : IReadOnlyCollection<KeyValuePair<TokenSymbolHandle, LrAction>>
     {
         private readonly LrStateMachine _lr;
 
@@ -78,15 +78,15 @@ public readonly struct LrState
         /// </summary>
         public Enumerator GetEnumerator() => new(this);
 
-        IEnumerator<KeyValuePair<TokenSymbolHandle, LrTerminalAction>>
-            IEnumerable<KeyValuePair<TokenSymbolHandle, LrTerminalAction>>.GetEnumerator() => GetEnumerator();
+        IEnumerator<KeyValuePair<TokenSymbolHandle, LrAction>>
+            IEnumerable<KeyValuePair<TokenSymbolHandle, LrAction>>.GetEnumerator() => GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <summary>
         /// Used to enumerate an <see cref="ActionCollection"/>.
         /// </summary>
-        public struct Enumerator : IEnumerator<KeyValuePair<TokenSymbolHandle, LrTerminalAction>>
+        public struct Enumerator : IEnumerator<KeyValuePair<TokenSymbolHandle, LrAction>>
         {
             private readonly ActionCollection _collection;
 
@@ -98,7 +98,7 @@ public readonly struct LrState
             }
 
             /// <inheritdoc/>
-            public KeyValuePair<TokenSymbolHandle, LrTerminalAction> Current
+            public KeyValuePair<TokenSymbolHandle, LrAction> Current
             {
                 get
                 {

--- a/src/FarkleNeo/Grammars/StateMachines/LrState.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrState.cs
@@ -10,9 +10,12 @@ namespace Farkle.Grammars.StateMachines;
 /// Represents a state of an <see cref="LrStateMachine"/>.
 /// </summary>
 [DebuggerDisplay("{DebuggerDisplay(),nq}")]
+[DebuggerTypeProxy(typeof(LrStateProxy))]
 public readonly struct LrState
 {
     private readonly LrStateMachine _lr;
+
+    internal Grammar Grammar => _lr.Grammar;
 
     /// <summary>
     /// The index of the <see cref="LrState"/>, starting from 0.

--- a/src/FarkleNeo/Grammars/StateMachines/LrState.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrState.cs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 using System.Collections;
+using System.Diagnostics;
 
 namespace Farkle.Grammars.StateMachines;
 
 /// <summary>
 /// Represents a state of an <see cref="LrStateMachine"/>.
 /// </summary>
+[DebuggerDisplay("{DebuggerDisplay(),nq}")]
 public readonly struct LrState
 {
     private readonly LrStateMachine _lr;
@@ -22,6 +24,9 @@ public readonly struct LrState
         _lr = lr;
         StateIndex = stateIndex;
     }
+
+    private string DebuggerDisplay() =>
+        $"{Actions.Count + EndOfFileActions.Count} actions, {Gotos.Count} gotos{(HasConflicts ? ", has conflicts" : "")}";
 
     /// <summary>
     /// The terminals the <see cref="LrState"/> accepts, along

--- a/src/FarkleNeo/Grammars/StateMachines/LrState.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrState.cs
@@ -54,6 +54,7 @@ public readonly struct LrState
     /// Contains the terminals an <see cref="LrState"/> accepts,
     /// along with their respective <see cref="LrTerminalAction"/>.
     /// </summary>
+    [DebuggerTypeProxy(typeof(FlatCollectionProxy<KeyValuePair<TokenSymbolHandle, LrTerminalAction>, ActionCollection>))]
     public readonly struct ActionCollection : IReadOnlyCollection<KeyValuePair<TokenSymbolHandle, LrTerminalAction>>
     {
         private readonly LrStateMachine _lr;
@@ -129,6 +130,7 @@ public readonly struct LrState
     /// <summary>
     /// Contains the possible actions when the end of input is reached at an <see cref="LrState"/>.
     /// </summary>
+    [DebuggerTypeProxy(typeof(FlatCollectionProxy<LrEndOfFileAction, EndOfFileActionCollection>))]
     public readonly struct EndOfFileActionCollection : IReadOnlyCollection<LrEndOfFileAction>
     {
         private readonly LrStateMachine _lr;
@@ -203,6 +205,7 @@ public readonly struct LrState
     /// <summary>
     /// Contains pairs of <see cref="NonterminalHandle"/>s and their respective GOTO destination states.
     /// </summary>
+    [DebuggerTypeProxy(typeof(FlatCollectionProxy<KeyValuePair<NonterminalHandle, int>, GotoCollection>))]
     public readonly struct GotoCollection : IReadOnlyCollection<KeyValuePair<NonterminalHandle, int>>
     {
         private readonly LrStateMachine _lr;

--- a/src/FarkleNeo/Grammars/StateMachines/LrState.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrState.cs
@@ -86,7 +86,7 @@ public readonly struct LrState
         {
             private readonly ActionCollection _collection;
 
-            private int _currentIndex;
+            private int _currentIndex = -1;
 
             internal Enumerator(ActionCollection collection)
             {
@@ -160,7 +160,7 @@ public readonly struct LrState
         {
             private readonly EndOfFileActionCollection _collection;
 
-            private int _currentIndex;
+            private int _currentIndex = -1;
 
             internal Enumerator(EndOfFileActionCollection collection)
             {
@@ -235,7 +235,7 @@ public readonly struct LrState
         {
             private readonly GotoCollection _collection;
 
-            private int _currentIndex;
+            private int _currentIndex = -1;
 
             internal Enumerator(GotoCollection collection)
             {

--- a/src/FarkleNeo/Grammars/StateMachines/LrStateMachine.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrStateMachine.cs
@@ -24,7 +24,7 @@ public abstract class LrStateMachine : IReadOnlyList<LrState>
 
     internal abstract (int Offset, int Count) GetActionBounds(int state);
 
-    internal abstract KeyValuePair<TokenSymbolHandle, LrTerminalAction> GetActionAt(int state);
+    internal abstract KeyValuePair<TokenSymbolHandle, LrAction> GetActionAt(int state);
 
     internal abstract (int Offset, int Count) GetEndOfFileActionBounds(int state);
 
@@ -107,7 +107,7 @@ public abstract class LrStateMachine : IReadOnlyList<LrState>
     /// <param name="state">The current state.</param>
     /// <param name="terminal">The terminal that was encountered.</param>
     /// <exception cref="NotSupportedException">The <see cref="LrStateMachine"/> has conflicts.</exception>
-    public abstract LrTerminalAction GetTerminalAction(int state, TokenSymbolHandle terminal);
+    public abstract LrAction GetAction(int state, TokenSymbolHandle terminal);
 
     /// <summary>
     /// Gets the next action from a state, when the end of the input stream is reached.

--- a/src/FarkleNeo/Grammars/StateMachines/LrStateMachine.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrStateMachine.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 namespace Farkle.Grammars.StateMachines;
 
 /// <summary>
-/// Represents an LR(1) state machine stored in a <see cref="Grammar"/>.
+/// Represents an LR(1) state machine stored in a <see cref="Grammars.Grammar"/>.
 /// It is used by parsers to parse tokens produced by tokenizers.
 /// </summary>
 [DebuggerDisplay("Count = {Count}; HasConflicts = {HasConflicts}}")]
@@ -18,6 +18,8 @@ public abstract class LrStateMachine : IReadOnlyList<LrState>
         Count = count;
         HasConflicts = hasConflicts;
     }
+
+    internal abstract Grammar Grammar { get; }
 
     internal abstract (int Offset, int Count) GetActionBounds(int state);
 

--- a/src/FarkleNeo/Grammars/StateMachines/LrStateMachine.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrStateMachine.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using System.Collections;
+using System.Diagnostics;
 
 namespace Farkle.Grammars.StateMachines;
 
@@ -9,6 +10,7 @@ namespace Farkle.Grammars.StateMachines;
 /// Represents an LR(1) state machine stored in a <see cref="Grammar"/>.
 /// It is used by parsers to parse tokens produced by tokenizers.
 /// </summary>
+[DebuggerDisplay("Count = {Count}")]
 public abstract class LrStateMachine : IReadOnlyList<LrState>
 {
     internal LrStateMachine(int count, bool hasConflicts)

--- a/src/FarkleNeo/Grammars/StateMachines/LrStateMachine.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrStateMachine.cs
@@ -107,6 +107,7 @@ public abstract class LrStateMachine : IReadOnlyList<LrState>
     /// <param name="state">The current state.</param>
     /// <param name="terminal">The terminal that was encountered.</param>
     /// <exception cref="NotSupportedException">The <see cref="LrStateMachine"/> has conflicts.</exception>
+    /// <remarks>This method is intended to be used by parsers.</remarks>
     public abstract LrAction GetAction(int state, TokenSymbolHandle terminal);
 
     /// <summary>
@@ -114,19 +115,8 @@ public abstract class LrStateMachine : IReadOnlyList<LrState>
     /// </summary>
     /// <param name="state">The current state.</param>
     /// <exception cref="NotSupportedException">The <see cref="LrStateMachine"/> has conflicts.</exception>
-    public virtual LrEndOfFileAction GetEndOfFileAction(int state)
-    {
-        switch (GetEndOfFileActionBounds(state))
-        {
-            case (int offset, 1):
-                return GetEndOfFileActionAt(offset);
-            case (_, 0):
-                return LrEndOfFileAction.Error;
-            default:
-                ThrowHelpers.ThrowInvalidOperationException("The LR state has more than one end-of-file action.");
-                return default;
-        }
-    }
+    /// <remarks>This method is intended to be used by parsers.</remarks>
+    public abstract LrEndOfFileAction GetEndOfFileAction(int state);
 
     /// <summary>
     /// Performs a GOTO transition from one state to another, based on a nonterminal produced by a reduction.
@@ -136,6 +126,7 @@ public abstract class LrStateMachine : IReadOnlyList<LrState>
     /// <returns>The index of the state to go to.</returns>
     /// <exception cref="KeyNotFoundException">A GOTO was not found for this state and nonterminal.
     /// Properly written parsers and grammar files should not encounter this exception.</exception>
+    /// <remarks>This method is intended to be used by parsers.</remarks>
     public abstract int GetGoto(int state, NonterminalHandle nonterminal);
 
     /// <summary>

--- a/src/FarkleNeo/Grammars/StateMachines/LrStateMachine.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrStateMachine.cs
@@ -11,6 +11,7 @@ namespace Farkle.Grammars.StateMachines;
 /// It is used by parsers to parse tokens produced by tokenizers.
 /// </summary>
 [DebuggerDisplay("Count = {Count}; HasConflicts = {HasConflicts}}")]
+[DebuggerTypeProxy(typeof(FlatCollectionProxy<LrState, LrStateMachine>))]
 public abstract class LrStateMachine : IReadOnlyList<LrState>
 {
     internal LrStateMachine(int count, bool hasConflicts)

--- a/src/FarkleNeo/Grammars/StateMachines/LrStateMachine.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrStateMachine.cs
@@ -10,7 +10,7 @@ namespace Farkle.Grammars.StateMachines;
 /// Represents an LR(1) state machine stored in a <see cref="Grammar"/>.
 /// It is used by parsers to parse tokens produced by tokenizers.
 /// </summary>
-[DebuggerDisplay("Count = {Count}")]
+[DebuggerDisplay("Count = {Count}; HasConflicts = {HasConflicts}}")]
 public abstract class LrStateMachine : IReadOnlyList<LrState>
 {
     internal LrStateMachine(int count, bool hasConflicts)

--- a/src/FarkleNeo/Grammars/StateMachines/LrTerminalAction.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrTerminalAction.cs
@@ -134,6 +134,21 @@ public readonly struct LrTerminalAction : IEquatable<LrTerminalAction>
         return "Error";
     }
 
+    internal string ToString(Grammar grammar)
+    {
+        if (IsShift)
+        {
+            return $"Shift to state {ShiftState}";
+        }
+
+        if (IsReduce)
+        {
+            return $"Reduce production {grammar.GetProduction(ReduceProduction)}";
+        }
+
+        return "Error";
+    }
+
     /// <summary>
     /// Checks two <see cref="LrTerminalAction"/>s for equality.
     /// </summary>

--- a/src/FarkleNeo/Grammars/StateMachines/LrWithConflicts.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrWithConflicts.cs
@@ -62,11 +62,11 @@ internal unsafe sealed class LrWithConflicts<TStateIndex, TActionIndex, TGotoInd
         };
     }
 
-    public override LrAction GetAction(int state, TokenSymbolHandle terminal)
-    {
-        ThrowHasConflicts();
-        return default;
-    }
+    public override LrAction GetAction(int state, TokenSymbolHandle terminal) =>
+        throw CreateHasConflictsException();
+
+    public override LrEndOfFileAction GetEndOfFileAction(int state) =>
+        throw CreateHasConflictsException();
 
     internal override LrEndOfFileAction GetEndOfFileActionAt(int index)
     {
@@ -91,7 +91,6 @@ internal unsafe sealed class LrWithConflicts<TStateIndex, TActionIndex, TGotoInd
         return (firstEofAction, nextFirstEofAction - firstEofAction);
     }
 
-    [DoesNotReturn, StackTraceHidden]
-    private static void ThrowHasConflicts() =>
-        ThrowHelpers.ThrowNotSupportedException("State machine has conflicts.");
+    private static NotSupportedException CreateHasConflictsException() =>
+        new("State machine has conflicts.");
 }

--- a/src/FarkleNeo/Grammars/StateMachines/LrWithConflicts.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrWithConflicts.cs
@@ -62,7 +62,7 @@ internal unsafe sealed class LrWithConflicts<TStateIndex, TActionIndex, TGotoInd
         };
     }
 
-    public override LrTerminalAction GetTerminalAction(int state, TokenSymbolHandle terminal)
+    public override LrAction GetAction(int state, TokenSymbolHandle terminal)
     {
         ThrowHasConflicts();
         return default;

--- a/src/FarkleNeo/Grammars/StateMachines/LrWithConflicts.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrWithConflicts.cs
@@ -68,12 +68,6 @@ internal unsafe sealed class LrWithConflicts<TStateIndex, TActionIndex, TGotoInd
         return default;
     }
 
-    public override int GetGoto(int state, NonterminalHandle nonterminal)
-    {
-        ThrowHasConflicts();
-        return default;
-    }
-
     internal override LrEndOfFileAction GetEndOfFileActionAt(int index)
     {
         if ((uint)index >= (uint)_eofActionCount)

--- a/src/FarkleNeo/Grammars/StateMachines/LrWithoutConflicts.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrWithoutConflicts.cs
@@ -74,13 +74,15 @@ internal unsafe sealed class LrWithoutConflicts<TStateIndex, TActionIndex, TGoto
         return LrAction.Error;
     }
 
-    internal override LrEndOfFileAction GetEndOfFileActionAt(int index)
+    public override LrEndOfFileAction GetEndOfFileAction(int state)
     {
-        ValidateStateIndex(index);
+        ValidateStateIndex(state);
 
         ReadOnlySpan<byte> grammarFile = Grammar.GrammarFile;
-        return new(ReadUIntVariableSizeFromArray<TActionIndex>(grammarFile, EofActionBase, index));
+        return new(ReadUIntVariableSizeFromArray<TActionIndex>(grammarFile, EofActionBase, state));
     }
+
+    internal override LrEndOfFileAction GetEndOfFileActionAt(int index) => GetEndOfFileAction(index);
 
     internal override (int Offset, int Count) GetEndOfFileActionBounds(int state)
     {

--- a/src/FarkleNeo/Grammars/StateMachines/LrWithoutConflicts.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrWithoutConflicts.cs
@@ -74,30 +74,6 @@ internal unsafe sealed class LrWithoutConflicts<TStateIndex, TActionIndex, TGoto
         return LrAction.Error;
     }
 
-    public override int GetGoto(int state, NonterminalHandle nonterminal)
-    {
-        ValidateStateIndex(state);
-
-        ReadOnlySpan<byte> grammarFile = Grammar.GrammarFile;
-
-        int gotoOffset = ReadFirstGoto(grammarFile, state);
-        int nextGotoOffset = state != Count - 1 ? ReadFirstGoto(grammarFile, state + 1) : GotoCount;
-        int gotoCount = nextGotoOffset - gotoOffset;
-
-        if (gotoCount != 0)
-        {
-            int nextGoto = StateMachineUtilities.BufferBinarySearch(grammarFile, GotoNonterminalBase + gotoOffset * sizeof(TNonterminal), gotoCount, StateMachineUtilities.CastUInt<TNonterminal>(nonterminal.TableIndex));
-
-            if (nextGoto >= 0)
-            {
-                return ReadGoto(grammarFile, gotoOffset + nextGoto);
-            }
-        }
-
-        ThrowHelpers.ThrowKeyNotFoundException("Could not find GOTO transition");
-        return 0;
-    }
-
     internal override LrEndOfFileAction GetEndOfFileActionAt(int index)
     {
         ValidateStateIndex(index);

--- a/src/FarkleNeo/Grammars/StateMachines/LrWithoutConflicts.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrWithoutConflicts.cs
@@ -51,7 +51,7 @@ internal unsafe sealed class LrWithoutConflicts<TStateIndex, TActionIndex, TGoto
 
     internal override bool StateHasConflicts(int state) => false;
 
-    public override LrTerminalAction GetTerminalAction(int state, TokenSymbolHandle terminal)
+    public override LrAction GetAction(int state, TokenSymbolHandle terminal)
     {
         ValidateStateIndex(state);
 
@@ -71,7 +71,7 @@ internal unsafe sealed class LrWithoutConflicts<TStateIndex, TActionIndex, TGoto
             }
         }
 
-        return LrTerminalAction.Error;
+        return LrAction.Error;
     }
 
     public override int GetGoto(int state, NonterminalHandle nonterminal)

--- a/src/FarkleNeo/Grammars/StateMachines/StateMachineUtilities.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/StateMachineUtilities.cs
@@ -233,7 +233,7 @@ internal static class StateMachineUtilities
             _ => Stage3<TStateIndex, TActionIndex, uint>()
         };
 
-        LrStateMachine Stage3<TStateIndex, TActionIndex, TGotoIndex>() => LrTerminalAction.GetEncodedSize(stateCount, grammar.GrammarTables.ProductionRowCount) switch
+        LrStateMachine Stage3<TStateIndex, TActionIndex, TGotoIndex>() => LrAction.GetEncodedSize(stateCount, grammar.GrammarTables.ProductionRowCount) switch
         {
             1 => Stage4<TStateIndex, TActionIndex, TGotoIndex, sbyte>(),
             2 => Stage4<TStateIndex, TActionIndex, TGotoIndex, short>(),
@@ -313,7 +313,7 @@ internal static class StateMachineUtilities
             _ => Stage4<TStateIndex, TActionIndex, TGotoIndex, uint>()
         };
 
-        LrStateMachine Stage4<TStateIndex, TActionIndex, TGotoIndex, TEofActionIndex>() => LrTerminalAction.GetEncodedSize(stateCount, grammar.GrammarTables.ProductionRowCount) switch
+        LrStateMachine Stage4<TStateIndex, TActionIndex, TGotoIndex, TEofActionIndex>() => LrAction.GetEncodedSize(stateCount, grammar.GrammarTables.ProductionRowCount) switch
         {
             1 => Stage5<TStateIndex, TActionIndex, TGotoIndex, TEofActionIndex, sbyte>(),
             2 => Stage5<TStateIndex, TActionIndex, TGotoIndex, TEofActionIndex, short>(),

--- a/src/FarkleNeo/Grammars/TokenSymbol.cs
+++ b/src/FarkleNeo/Grammars/TokenSymbol.cs
@@ -55,4 +55,31 @@ public readonly struct TokenSymbol
             return _grammar.GrammarTables.GetTokenSymbolFlags(_grammar.GrammarFile, Handle.TableIndex);
         }
     }
+
+    /// <summary>
+    /// Returns a string describing the the <see cref="TokenSymbol"/>.
+    /// </summary>
+    public override string ToString()
+    {
+        string name = _grammar.GetString(Name);
+
+        return ShouldQuote(name) ? $"'{name}'" : name;
+
+        static bool ShouldQuote(string str)
+        {
+            if (str is "" || !char.IsLetter(str[0]))
+            {
+                return true;
+            }
+
+            foreach (char c in str)
+            {
+                if (!char.IsLetter(c) && c is not ('.' or '-' or '_'))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
 }

--- a/src/FarkleNeo/Grammars/TokenSymbolCollection.cs
+++ b/src/FarkleNeo/Grammars/TokenSymbolCollection.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using System.Collections;
+using System.Diagnostics;
 
 namespace Farkle.Grammars;
 
@@ -10,6 +11,7 @@ namespace Farkle.Grammars;
 /// </summary>
 /// <seealso cref="Grammar.Terminals"/>
 /// <seealso cref="Grammar.TokenSymbols"/>
+[DebuggerDisplay("Count = {Count}")]
 public readonly struct TokenSymbolCollection : IReadOnlyCollection<TokenSymbol>
 {
     private readonly Grammar _grammar;

--- a/src/FarkleNeo/Grammars/TokenSymbolCollection.cs
+++ b/src/FarkleNeo/Grammars/TokenSymbolCollection.cs
@@ -12,6 +12,7 @@ namespace Farkle.Grammars;
 /// <seealso cref="Grammar.Terminals"/>
 /// <seealso cref="Grammar.TokenSymbols"/>
 [DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(FlatCollectionProxy<TokenSymbol, TokenSymbolCollection>))]
 public readonly struct TokenSymbolCollection : IReadOnlyCollection<TokenSymbol>
 {
     private readonly Grammar _grammar;

--- a/src/FarkleNeo/Grammars/TokenSymbolHandle.cs
+++ b/src/FarkleNeo/Grammars/TokenSymbolHandle.cs
@@ -53,6 +53,11 @@ public readonly struct TokenSymbolHandle : IEquatable<TokenSymbolHandle>
     public override int GetHashCode() => TableIndex.GetHashCode();
 
     /// <summary>
+    /// Returns a string describing the the <see cref="TokenSymbolHandle"/>.
+    /// </summary>
+    public override string ToString() => HasValue ? Value.ToString() : "<null>";
+
+    /// <summary>
     /// Checks if two <see cref="TokenSymbolHandle"/>s are pointing to the same row.
     /// </summary>
     /// <param name="left">The first handle.</param>

--- a/src/FarkleNeo/Grammars/Writers/LrWriter.cs
+++ b/src/FarkleNeo/Grammars/Writers/LrWriter.cs
@@ -45,7 +45,7 @@ internal sealed class LrWriter
     {
         EnsureNotFinished();
 
-        AddAction(terminal, LrTerminalAction.CreateReduce(production));
+        AddAction(terminal, LrAction.CreateReduce(production));
 
         if (production.TableIndex > _maxProduction)
         {
@@ -58,10 +58,10 @@ internal sealed class LrWriter
         EnsureNotFinished();
         ValidateState(state);
 
-        AddAction(terminal, LrTerminalAction.CreateShift(state));
+        AddAction(terminal, LrAction.CreateShift(state));
     }
 
-    private void AddAction(TokenSymbolHandle terminal, LrTerminalAction action)
+    private void AddAction(TokenSymbolHandle terminal, LrAction action)
     {
         if (terminal.TableIndex > _maxTerminal)
         {
@@ -202,7 +202,7 @@ internal sealed class LrWriter
 
         byte stateIndexSize = StateMachineUtilities.GetIndexSize(StateCount);
         byte actionIndexSize = StateMachineUtilities.GetIndexSize(_actions.Count);
-        byte actionSize = LrTerminalAction.GetEncodedSize(StateCount, productionCount);
+        byte actionSize = LrAction.GetEncodedSize(StateCount, productionCount);
         byte eofActionSize = LrEndOfFileAction.GetEncodedSize(productionCount);
         byte gotoIndexSize = StateMachineUtilities.GetIndexSize(_gotos.Count);
         byte nonterminalIndexSize = GrammarTables.GetIndexSize(nonterminalCount);

--- a/tests/Farkle.Tests.CSharp/GrammarTests.cs
+++ b/tests/Farkle.Tests.CSharp/GrammarTests.cs
@@ -68,6 +68,10 @@ internal class GrammarTests
 
         Assert.Multiple(() =>
         {
+            Assert.That(grammar.GrammarInfo.Name.IsEmpty, Is.False);
+            Assert.That(() => grammar.GrammarInfo.Attributes, Throws.Nothing);
+            Assert.That(grammar.GrammarInfo.StartSymbol.HasValue);
+
             foreach (var tokenSymbol in grammar.TokenSymbols)
             {
                 Assert.That(tokenSymbol.Name.IsEmpty, Is.False);
@@ -87,20 +91,15 @@ internal class GrammarTests
                 Assert.That(() => group.Attributes, Throws.Nothing);
                 Assert.That(group.Start.HasValue);
                 Assert.That(group.End.HasValue);
-                foreach (var nesting in group.Nesting)
-                {
-                    Assert.That(nesting.Name.IsEmpty, Is.False);
-                }
+                Assert.That(group.Nesting.Count(), Is.EqualTo(group.Nesting.Count));
             }
 
             foreach (var production in grammar.Productions)
             {
                 Assert.That(production.Head.HasValue);
-                foreach (var member in production.Members)
-                {
-                    Assert.That(member.HasValue);
-                }
+                Assert.That(production.Members.Count(), Is.EqualTo(production.Members.Count));
             }
+
             if (grammar.DfaOnChar is { } dfa)
             {
                 int count = 0;
@@ -108,21 +107,22 @@ internal class GrammarTests
                 {
                     Assert.That(state.StateIndex, Is.EqualTo(count));
                     Assert.That(() => state.DefaultTransition, Throws.Nothing);
-                    Assert.That(() => { foreach (var edge in state.Edges) { } }, Throws.Nothing);
-                    Assert.That(() => { foreach (var acceptSymbol in state.AcceptSymbols) { } }, Throws.Nothing);
+                    Assert.That(state.Edges.Count(), Is.EqualTo(state.Edges.Count));
+                    Assert.That(state.AcceptSymbols.Count(), Is.EqualTo(state.AcceptSymbols.Count));
                     count++;
                 }
                 Assert.That(count, Is.EqualTo(dfa.Count));
             }
+
             if (grammar.LrStateMachine is { } lr)
             {
                 int count = 0;
                 foreach (var state in lr)
                 {
                     Assert.That(state.StateIndex, Is.EqualTo(count));
-                    Assert.That(() => { foreach (var action in state.Actions) { } }, Throws.Nothing);
-                    Assert.That(() => { foreach (var action in state.EndOfFileActions) { } }, Throws.Nothing);
-                    Assert.That(() => { foreach (var @goto in state.Gotos) { } }, Throws.Nothing);
+                    Assert.That(state.Actions.Count(), Is.EqualTo(state.Actions.Count));
+                    Assert.That(state.EndOfFileActions.Count(), Is.EqualTo(state.EndOfFileActions.Count));
+                    Assert.That(state.Gotos.Count(), Is.EqualTo(state.Gotos.Count));
                     count++;
                 }
                 Assert.That(count, Is.EqualTo(lr.Count));


### PR DESCRIPTION
This PR:

* Significantly improves browsing grammars under a debugger, especially when viewing DFA and LR states.
* Adds support for indexing a production's members; it makes sense because their order matters.
* Cleans-up the state machine API and makes it uniform across DFAs and LR state machines.