### PR TITLE
Fix heap handle validation and remove the debug-only checking of valid handles.

### DIFF
--- a/src/FarkleNeo/Grammars/Writers/BlobHeapWriter.cs
+++ b/src/FarkleNeo/Grammars/Writers/BlobHeapWriter.cs
@@ -15,9 +15,6 @@ internal struct BlobHeapWriter
 {
     private List<ImmutableArray<byte>>? _blobs;
     private BlobDictionary<BlobHandle>? _blobHandles;
-#if DEBUG
-    private HashSet<BlobHandle>? _validHandles;
-#endif
 
     public int LengthSoFar { get; private set; }
 
@@ -76,9 +73,6 @@ internal struct BlobHeapWriter
 
         BlobHandle handle = new((uint)LengthSoFar);
         handle = _blobHandles.GetOrAdd(blob, handle, out bool exists, out ImmutableArray<byte> immutableBlob);
-#if DEBUG
-        (_validHandles ??= new()).Add(handle);
-#endif
 
         if (!exists)
         {
@@ -91,16 +85,10 @@ internal struct BlobHeapWriter
 
     public void ValidateHandle(BlobHandle handle)
     {
-        if (handle.IsEmpty || handle.Value >= (uint)LengthSoFar)
+        if (handle.Value < (uint)LengthSoFar)
         {
             return;
         }
-#if DEBUG
-        if (_validHandles?.Contains(handle) ?? false)
-        {
-            return;
-        }
-#endif
         ThrowHelpers.ThrowArgumentException(nameof(handle), "Invalid blob handle.");
     }
 

--- a/src/FarkleNeo/Grammars/Writers/StringHeapWriter.cs
+++ b/src/FarkleNeo/Grammars/Writers/StringHeapWriter.cs
@@ -14,9 +14,6 @@ internal struct StringHeapWriter
 {
     private List<string>? _strings;
     private StringDictionary<StringHandle>? _stringHandles;
-#if DEBUG
-    private HashSet<StringHandle>? _validHandles;
-#endif
 
     public int LengthSoFar { get; private set; }
 
@@ -70,9 +67,6 @@ internal struct StringHeapWriter
 
         handle = new((uint)LengthSoFar);
         handle = _stringHandles.GetOrAdd(str, handle, out bool exists);
-#if DEBUG
-        (_validHandles ??= new()).Add(handle);
-#endif
         Debug.Assert(!exists);
 
         LengthSoFar += stringLength;
@@ -82,16 +76,10 @@ internal struct StringHeapWriter
 
     public void ValidateHandle(StringHandle handle)
     {
-        if (handle.IsEmpty || handle.Value >= (uint)LengthSoFar)
+        if (handle.Value < (uint)LengthSoFar)
         {
             return;
         }
-#if DEBUG
-        if (_validHandles?.Contains(handle) ?? false)
-        {
-            return;
-        }
-#endif
         ThrowHelpers.ThrowArgumentException(nameof(handle), "String handle is invalid.");
     }
 


### PR DESCRIPTION
This extra check masked the bug which was apparent only in Release mode. Content validation (once added) will ensure heap handles are valid.

Cherry-picked from the content validation PR.