### PR TITLE
Add grammar content validation.

### DIFF
--- a/designs/7.0/grammar-file-format-spec.md
+++ b/designs/7.0/grammar-file-format-spec.md
@@ -415,7 +415,6 @@ A GLR(1) state machine has at least one terminal and state where there is more t
     * The type `eof_action_index_t` is the smallest of one, two or four bytes that can hold the value of the `eofActionCount` field plus one.
 * The `eofAction` field's type is changed to `eof_action_t[eofActionCount]`.
 * For each state, duplicate values of the `actionTerminal` field are allowed.
-    * Nevertheless, the count of shift actions for a given state and terminal MUST NOT be greater than one. In other words, "shift-shift" conflicts are not allowed to be encoded.
 
 ## Extensibility
 

--- a/performance/Farkle.Benchmarks.CSharp/GrammarReaderBenchmark.cs
+++ b/performance/Farkle.Benchmarks.CSharp/GrammarReaderBenchmark.cs
@@ -37,6 +37,10 @@ public class GrammarReaderBenchmark
     public object ReadFarkle7() =>
         Grammar.Create(Farkle7Grammar);
 
+    [BenchmarkCategory("Read"), Benchmark]
+    public object ReadFarkle7NoValidation() =>
+        Grammar.CreateUnsafe(Farkle7Grammar);
+
     [BenchmarkCategory("Convert"), Benchmark(Baseline = true)]
     public object ConvertFarkle6() =>
         Farkle6.Grammar.EGT.ReadFromStream(new MemoryStream(Egt, false));

--- a/src/FarkleNeo/FarkleNeo.csproj
+++ b/src/FarkleNeo/FarkleNeo.csproj
@@ -11,6 +11,7 @@
     <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Farkle.Benchmarks.CSharp" />
     <InternalsVisibleTo Include="Farkle.Tests.CSharp" />
     <PackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="all" />
     <PackageReference Include="PolySharp" PrivateAssets="all" />

--- a/src/FarkleNeo/Grammars/BlobHeap.cs
+++ b/src/FarkleNeo/Grammars/BlobHeap.cs
@@ -37,7 +37,7 @@ internal readonly struct BlobHeap
         int blobContentStart = blobStart += blobContentStartOffset;
         if (BufferExtensions.IsOutOfBounds(blobContentStart, blobLength, Length))
         {
-            ThrowHelpers.ThrowArgumentOutOfRangeException(nameof(handle), "Invalid handle.");
+            ThrowHelpers.ThrowArgumentOutOfRangeException(nameof(handle), "Invalid blob handle.");
         }
 
         return new GrammarFileSection(Offset + blobContentStart, blobLength);

--- a/src/FarkleNeo/Grammars/Grammar.cs
+++ b/src/FarkleNeo/Grammars/Grammar.cs
@@ -314,6 +314,7 @@ public abstract class Grammar
 
         GrammarTables.ValidateContent(grammarFile, in StringHeap, in BlobHeap);
         LrStateMachine?.ValidateContent(grammarFile, in GrammarTables);
+        DfaOnChar?.ValidateContent(grammarFile, in GrammarTables);
     }
 
     /// <summary>

--- a/src/FarkleNeo/Grammars/Grammar.cs
+++ b/src/FarkleNeo/Grammars/Grammar.cs
@@ -129,7 +129,9 @@ public abstract class Grammar
         {
             ThrowHelpers.ThrowArgumentNullException(nameof(grammarData));
         }
-        return new ManagedMemoryGrammar(grammarData);
+        ManagedMemoryGrammar grammar = new ManagedMemoryGrammar(grammarData);
+        grammar.ValidateContent();
+        return grammar;
     }
 
     /// <summary>
@@ -145,7 +147,9 @@ public abstract class Grammar
     /// </remarks>
     public static Grammar Create(ReadOnlySpan<byte> grammarData)
     {
-        return new ManagedMemoryGrammar(grammarData);
+        ManagedMemoryGrammar grammar = new ManagedMemoryGrammar(grammarData);
+        grammar.ValidateContent();
+        return grammar;
     }
 
     /// <summary>
@@ -303,6 +307,13 @@ public abstract class Grammar
     /// <param name="destination">The span to copy the data to.</param>
     /// <returns>Whether <paramref name="destination"/> was big enough to store the grammar's data.</returns>
     public bool TryCopyDataTo(Span<byte> destination) => GrammarFile.TryCopyTo(destination);
+
+    internal void ValidateContent()
+    {
+        ReadOnlySpan<byte> grammarFile = GrammarFile;
+
+        GrammarTables.ValidateContent(grammarFile, in StringHeap, in BlobHeap);
+    }
 
     /// <summary>
     /// Writes the grammar's data to an <see cref="IBufferWriter{Byte}"/>.

--- a/src/FarkleNeo/Grammars/Grammar.cs
+++ b/src/FarkleNeo/Grammars/Grammar.cs
@@ -313,6 +313,7 @@ public abstract class Grammar
         ReadOnlySpan<byte> grammarFile = GrammarFile;
 
         GrammarTables.ValidateContent(grammarFile, in StringHeap, in BlobHeap);
+        LrStateMachine?.ValidateContent(grammarFile, in GrammarTables);
     }
 
     /// <summary>

--- a/src/FarkleNeo/Grammars/Grammar.cs
+++ b/src/FarkleNeo/Grammars/Grammar.cs
@@ -152,6 +152,17 @@ public abstract class Grammar
         return grammar;
     }
 
+    // Internal for benchmarking purposes.
+    // It can be made public once a [RequiresUnsafe] attribute is added.
+    internal static Grammar CreateUnsafe(ImmutableArray<byte> grammarData)
+    {
+        if (grammarData.IsDefault)
+        {
+            ThrowHelpers.ThrowArgumentNullException(nameof(grammarData));
+        }
+        return new ManagedMemoryGrammar(grammarData);
+    }
+
     /// <summary>
     /// Converts a grammar file produced by GOLD Parser into a <see cref="Grammar"/>.
     /// </summary>

--- a/src/FarkleNeo/Grammars/GrammarTables.cs
+++ b/src/FarkleNeo/Grammars/GrammarTables.cs
@@ -565,11 +565,11 @@ internal readonly struct GrammarTables
         }
     }
 
-    private void ValidateHandle(TokenSymbolHandle handle) => ValidateHandle(handle.TableIndex, TokenSymbolRowCount);
+    internal void ValidateHandle(TokenSymbolHandle handle) => ValidateHandle(handle.TableIndex, TokenSymbolRowCount);
 
-    private void ValidateHandle(NonterminalHandle handle) => ValidateHandle(handle.TableIndex, NonterminalRowCount);
+    internal void ValidateHandle(NonterminalHandle handle) => ValidateHandle(handle.TableIndex, NonterminalRowCount);
 
-    private void ValidateHandle(ProductionHandle handle) => ValidateHandle(handle.TableIndex, ProductionRowCount);
+    internal void ValidateHandle(ProductionHandle handle) => ValidateHandle(handle.TableIndex, ProductionRowCount);
 
     private static void ValidateHandle(uint tableIndex, int rowCount)
     {

--- a/src/FarkleNeo/Grammars/GrammarTables.cs
+++ b/src/FarkleNeo/Grammars/GrammarTables.cs
@@ -468,13 +468,10 @@ internal readonly struct GrammarTables
                 uint firstNesting = GetGroupFirstNesting(grammarFile, i);
                 Assert(firstNesting >= previousFirstNesting, "Group first nestings are out of sequence.");
                 previousFirstNesting = firstNesting;
-                if (i != (uint)GroupRowCount)
-                {
-                    ValidateHandle(firstNesting, GroupNestingRowCount);
-                }
+                // The First*** columns can be one number bigger than their respective row count.
+                // This can happen if the row and all its subsequent ones have no child items.
+                ValidateHandle(firstNesting, GroupNestingRowCount + 1);
             }
-            // The last first group nesting can be one greater than the group nesting row count.
-            ValidateHandle(previousFirstNesting, GroupNestingRowCount + 1);
             Assert(groupStarts.Count == 0, "All token symbols with the GroupStart flag set must start a group.");
         }
 
@@ -498,12 +495,8 @@ internal readonly struct GrammarTables
                 ProductionHandle firstProduction = GetNonterminalFirstProduction(grammarFile, i);
                 Assert(firstProduction.TableIndex >= previousFirstProduction.TableIndex, "Nonterminal first productions are out of sequence.");
                 previousFirstProduction = firstProduction;
-                if (i != (uint)NonterminalRowCount)
-                {
-                    ValidateHandle(firstProduction);
-                }
+                ValidateHandle(firstProduction.TableIndex, ProductionRowCount + 1);
             }
-            ValidateHandle(previousFirstProduction.TableIndex, ProductionRowCount + 1);
         }
 
         if (ProductionRowCount != 0)
@@ -523,10 +516,7 @@ internal readonly struct GrammarTables
                 uint firstMember = GetProductionFirstMember(grammarFile, i);
                 Assert(firstMember >= previousFirstMember, "Production first members are out of sequence.");
                 previousFirstMember = firstMember;
-                if (i != (uint)ProductionRowCount)
-                {
-                    ValidateHandle(firstMember, ProductionMemberRowCount);
-                }
+                ValidateHandle(firstMember, ProductionMemberRowCount + 1);
             }
             Assert(currentHead == NonterminalRowCount);
         }

--- a/src/FarkleNeo/Grammars/StateMachines/Dfa.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/Dfa.cs
@@ -42,6 +42,8 @@ public abstract class Dfa<TChar> : IReadOnlyList<DfaState<TChar>>
 
     internal virtual bool StateHasConflicts(int state) => GetAcceptSymbolBounds(state).Count > 1;
 
+    internal abstract void ValidateContent(ReadOnlySpan<byte> grammarFile, in GrammarTables grammarTables);
+
     /// <summary>
     /// The number of the <see cref="Dfa{TChar}"/>'s initial state.
     /// </summary>

--- a/src/FarkleNeo/Grammars/StateMachines/DfaImplementationBase.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/DfaImplementationBase.cs
@@ -3,6 +3,7 @@
 
 using Farkle.Buffers;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Farkle.Grammars.StateMachines;
@@ -73,28 +74,41 @@ internal unsafe abstract class DfaImplementationBase<TChar, TState, TEdge> : Dfa
 
     internal sealed override Grammar Grammar { get; }
 
+    private int GetDefaultTransitionUnsafe(ReadOnlySpan<byte> grammarFile, int state)
+    {
+        return ReadState(grammarFile, DefaultTransitionBase + state * sizeof(TState));
+    }
+
+    private (int Offset, int Count) GetEdgeBoundsUnsafe(ReadOnlySpan<byte> grammarFile, int state)
+    {
+        int edgeOffset = ReadFirstEdge(grammarFile, state);
+        int nextEdgeOffset = state != Count - 1 ? ReadFirstEdge(grammarFile, state + 1) : _edgeCount;
+        return (edgeOffset, nextEdgeOffset - edgeOffset);
+    }
+
+    private DfaEdge<TChar> GetEdgeAtUnsafe(ReadOnlySpan<byte> grammarFile, int index)
+    {
+        TChar cFrom = StateMachineUtilities.Read<TChar>(grammarFile, RangeFromBase + index * sizeof(char));
+        TChar cTo = StateMachineUtilities.Read<TChar>(grammarFile, RangeToBase + index * sizeof(char));
+        int target = ReadState(grammarFile, EdgeTargetBase + index * sizeof(TState));
+
+        return new(cFrom, cTo, target);
+    }
+
     internal sealed override int GetDefaultTransition(int state)
     {
         ValidateStateIndex(state);
-
         if (DefaultTransitionBase == 0)
         {
             return -1;
         }
-
-        return ReadState(Grammar.GrammarFile, DefaultTransitionBase + state * sizeof(TState));
+        return GetDefaultTransitionUnsafe(Grammar.GrammarFile, state);
     }
 
     internal sealed override (int Offset, int Count) GetEdgeBounds(int state)
     {
         ValidateStateIndex(state);
-
-        ReadOnlySpan<byte> grammarFile = Grammar.GrammarFile;
-
-        int edgeOffset = ReadFirstEdge(grammarFile, state);
-        int nextEdgeOffset = state != Count - 1 ? ReadFirstEdge(grammarFile, state + 1) : _edgeCount;
-
-        return (edgeOffset, nextEdgeOffset - edgeOffset);
+        return GetEdgeBoundsUnsafe(Grammar.GrammarFile, state);
     }
 
     internal sealed override DfaEdge<TChar> GetEdgeAt(int index)
@@ -103,14 +117,59 @@ internal unsafe abstract class DfaImplementationBase<TChar, TState, TEdge> : Dfa
         {
             ThrowHelpers.ThrowArgumentOutOfRangeException(nameof(index));
         }
+        return GetEdgeAtUnsafe(Grammar.GrammarFile, index);
+    }
 
-        ReadOnlySpan<byte> grammarFile = Grammar.GrammarFile;
+    internal override void ValidateContent(ReadOnlySpan<byte> grammarFile, in GrammarTables grammarTables)
+    {
+        {
+            int previousFirstEdge = ReadFirstEdge(grammarFile, 0);
+            Assert(previousFirstEdge == 0);
+            for (int i = 1; i < Count; i++)
+            {
+                int firstAction = ReadFirstEdge(grammarFile, i);
+                Assert(firstAction >= previousFirstEdge, "DFA state first edge is out of sequence.");
+                previousFirstEdge = firstAction;
+                Assert(firstAction <= _edgeCount);
+            }
+        }
 
-        TChar cFrom = StateMachineUtilities.Read<TChar>(grammarFile, RangeFromBase + index * sizeof(char));
-        TChar cTo = StateMachineUtilities.Read<TChar>(grammarFile, RangeToBase + index * sizeof(char));
-        int target = ReadState(grammarFile, EdgeTargetBase + index * sizeof(TState));
+        for (int i = 0; i < Count; i++)
+        {
+            (int edgeOffset, int edgeCount) = GetEdgeBoundsUnsafe(grammarFile, i);
+            if (edgeCount > 0)
+            {
+                TChar previousKeyTo = GetEdgeAtUnsafe(grammarFile, edgeOffset).KeyTo;
+                for (int j = 0; j < edgeCount; j++)
+                {
+                    DfaEdge<TChar> edge = GetEdgeAtUnsafe(grammarFile, edgeOffset + j);
+                    Assert(edge.KeyFrom.CompareTo(edge.KeyTo) <= 0, "DFA state edge range is inverted.");
+                    if (j != 0)
+                    {
+                        Assert(previousKeyTo.CompareTo(edge.KeyFrom) < 0, "DFA state edges are unsorted.");
+                    }
+                    previousKeyTo = edge.KeyTo;
+                    ValidateStateIndex(edge.Target);
+                }
+            }
+        }
 
-        return new(cFrom, cTo, target);
+        if (DefaultTransitionBase != 0)
+        {
+            for (int i = 0; i < Count; i++)
+            {
+                int defaultTransition = GetDefaultTransitionUnsafe(grammarFile, i);
+                ValidateStateIndex(defaultTransition);
+            }
+        }
+
+        static void Assert([DoesNotReturnIf(false)] bool condition, string? message = null)
+        {
+            if (!condition)
+            {
+                ThrowHelpers.ThrowInvalidDataException(message);
+            }
+        }
     }
 
     protected void ValidateStateIndex(int state, [CallerArgumentExpression(nameof(state))] string? paramName = null)

--- a/src/FarkleNeo/Grammars/StateMachines/LrImplementationBase.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrImplementationBase.cs
@@ -174,6 +174,7 @@ internal unsafe abstract class LrImplementationBase<TStateIndex, TActionIndex, T
                 {
                     KeyValuePair<TokenSymbolHandle, LrAction> action = GetActionAtUnsafe(grammarFile, actionOffset + j);
                     grammarTables.ValidateHandle(action.Key);
+                    Assert(grammarTables.IsTerminal(action.Key));
                     if (j != 0)
                     {
                         Assert(previousActionTerminal.CompareTo(action.Key.TableIndex) <= actionComparisonKey, "LR state terminal is out of sequence or unexpected LR conflict.");

--- a/src/FarkleNeo/Grammars/StateMachines/LrStateMachine.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrStateMachine.cs
@@ -34,6 +34,8 @@ public abstract class LrStateMachine : IReadOnlyList<LrState>
 
     internal abstract KeyValuePair<NonterminalHandle, int> GetGotoAt(int index);
 
+    internal abstract void ValidateContent(ReadOnlySpan<byte> grammarFile, in GrammarTables grammarTables);
+
     internal virtual bool StateHasConflicts(int state)
     {
         if (GetEndOfFileActionBounds(state).Count > 1)

--- a/src/FarkleNeo/Grammars/StateMachines/StateMachineUtilities.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/StateMachineUtilities.cs
@@ -3,7 +3,6 @@
 
 using Farkle.Buffers;
 using System.Buffers;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Farkle.Grammars.StateMachines;
 

--- a/src/FarkleNeo/Grammars/Writers/GrammarTablesWriter.cs
+++ b/src/FarkleNeo/Grammars/Writers/GrammarTablesWriter.cs
@@ -422,6 +422,7 @@ internal struct GrammarTablesWriter
                 remainingProductions--;
                 UpdateRemainingProductions();
             }
+            Debug.Assert(remainingProductions == 0 && currentNonterminal == nonterminals.Count - 1);
 
             // We track the head nonterminal by counting how many productions we have written
             // and how many productions are left in the current nonterminal. When we have finished

--- a/tests/Farkle.Tests.CSharp/GrammarTests.cs
+++ b/tests/Farkle.Tests.CSharp/GrammarTests.cs
@@ -48,6 +48,7 @@ internal class GrammarTests
     {
         var originalFarkleGrammar = File.ReadAllBytes(farkleGrammar);
         var convertedGrammar = ConvertGrammarFile(goldGrammar);
+        _ = Grammar.Create(convertedGrammar);
 
         Assert.That(convertedGrammar, Is.EqualTo(originalFarkleGrammar));
 


### PR DESCRIPTION
When Farkle loads a grammar file, it performs some validations to its _structure_. These validations are minimal and run in (almost) constant time.

But there might be errors with the grammar's _content_, like an LR action shifting to state 184, with only 137 states existing. This would result in either reading garbage data from later in the grammar or out-of-bounds reads once we remove these bounds checks, posing a security vulnerability when reading untrusted grammars. Therefore this PR introduces content validation (previously known as full validation) which traverses the entire grammar and validates that its tables, heaps and state machines contain valid data.

Content validation gets performed just before returning a grammar from the `Grammar.Create` methods. I could add `Grammar.CreateUnsafe` methods that skip it, but would prefer a `[RequiresUnsafe]` attribute being added to .NET first. Also content validation will be skipped when loading precompiled grammars once we add the precompiler; data in your own assembly does not cross a trust boundary.