### PR TITLE
Add localization support.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,13 +9,13 @@ insert_final_newline = true
 tab_width = 4
 trim_trailing_whitespace = true
 
-[*.{{*proj,props,targets},nuspec,config}]
+[*.{{*proj,props,targets},nuspec,config,resx,xml}]
 indent_size = 2
 
 [*.yml]
 indent_size = 2
 
-[*.json]
+[*.{json,resx}]
 # Some JSON files are edited by tools and do not have a trailing newline.
 insert_final_newline = unset
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,12 +17,19 @@ There are Visual Studio Code tasks to make your life easier.
 
 ## What to contribute
 
-__Farkle is undergoing a complete rewrite. Until it completes, community contributions to files under `src/Farkle` or `src/FarkleNeo` will not be accepted.__ You can contribute instead to:
+As the main Farkle library is undergoing a complete rewrite, contributions will be appreciated to the following areas:
 
 * Documentation
 * Tests
 * Samples
-* The CLI tool
+* The CLI tool (`src/Farkle.Tools`)
+* [Localizing](#localization) Farkle to a language you know
+
+### Localization
+
+Farkle's diagnostic messages can be localized. The officially supported languages are English and Greek. If you know any other language and want to translate them, it would be great!
+
+To do so you need to find the `.resx` files in the repository, and create a new one corresponding to your language's culture name.
 
 ## Breaking changes policy
 

--- a/src/FarkleNeo/FarkleNeo.csproj
+++ b/src/FarkleNeo/FarkleNeo.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="System.Memory" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Update="Properties/*.resx" ManifestResourceName="Farkle.%(Filename)" />
     <EmbeddedResource Include="ILLink.Substitutions.xml" LogicalName="ILLink.Substitutions.xml" />
   </ItemGroup>
 </Project>

--- a/src/FarkleNeo/FarkleNeo.csproj
+++ b/src/FarkleNeo/FarkleNeo.csproj
@@ -24,4 +24,7 @@
     <PackageReference Include="System.Buffers" />
     <PackageReference Include="System.Memory" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="ILLink.Substitutions.xml" LogicalName="ILLink.Substitutions.xml" />
+  </ItemGroup>
 </Project>

--- a/src/FarkleNeo/Grammars/GoldParser/GoldGrammarReader.cs
+++ b/src/FarkleNeo/Grammars/GoldParser/GoldGrammarReader.cs
@@ -16,17 +16,17 @@ internal static class GoldGrammarReader
         switch (header)
         {
             case GrammarConstants.HeaderMagicString:
-                errorMessage = "Grammar files produced by Farkle 7 and above must be opened with the Grammar.Create method.";
+                errorMessage = Resources.Grammar_Farkle7MustOpen;
                 break;
             case GrammarConstants.EgtNeoHeaderString:
-                errorMessage = "EGTneo grammar files produced by Farkle 6.x are not supported.";
+                errorMessage = Resources.Grammar_EgtNeoNotSupported;
                 break;
             case GrammarConstants.EgtHeaderString:
                 return true;
             case GrammarConstants.CgtHeaderString:
                 return false;
             default:
-                errorMessage = "Unrecognized file format.";
+                errorMessage = Resources.Grammar_UnrecognizedFormat;
                 break;
         }
 

--- a/src/FarkleNeo/Grammars/Grammar.cs
+++ b/src/FarkleNeo/Grammars/Grammar.cs
@@ -84,10 +84,10 @@ public abstract class Grammar
         string errorMessage = header.FileType switch
         {
             GrammarFileType.Farkle when header.VersionMajor > GrammarConstants.VersionMajor => Resources.Grammar_TooNewFormat,
-            GrammarFileType.Farkle => "The grammar's format version is too old for this version of Farkle to support.",
-            GrammarFileType.EgtNeo => "EGTneo grammar files produced by Farkle 6.x are not supported.",
-            GrammarFileType.GoldParser => "Grammar files produced by GOLD Parser must be opened with the Grammar.CreateFromGoldParserGrammar method.",
-            _ => "Unrecognized file format."
+            GrammarFileType.Farkle => Resources.Grammar_TooOldFormat,
+            GrammarFileType.EgtNeo => Resources.Grammar_EgtNeoNotSupported,
+            GrammarFileType.GoldParser => Resources.Grammar_GoldParserMustConvert,
+            _ => Resources.Grammar_UnrecognizedFormat
         };
         ThrowHelpers.ThrowNotSupportedException(errorMessage);
     }

--- a/src/FarkleNeo/Grammars/Grammar.cs
+++ b/src/FarkleNeo/Grammars/Grammar.cs
@@ -83,7 +83,7 @@ public abstract class Grammar
 
         string errorMessage = header.FileType switch
         {
-            GrammarFileType.Farkle when header.VersionMajor > GrammarConstants.VersionMajor => "The grammar's format version is too new for this version of Farkle to support.",
+            GrammarFileType.Farkle when header.VersionMajor > GrammarConstants.VersionMajor => Resources.Grammar_TooNewFormat,
             GrammarFileType.Farkle => "The grammar's format version is too old for this version of Farkle to support.",
             GrammarFileType.EgtNeo => "EGTneo grammar files produced by Farkle 6.x are not supported.",
             GrammarFileType.GoldParser => "Grammar files produced by GOLD Parser must be opened with the Grammar.CreateFromGoldParserGrammar method.",

--- a/src/FarkleNeo/ILLink.Substitutions.xml
+++ b/src/FarkleNeo/ILLink.Substitutions.xml
@@ -1,0 +1,9 @@
+<linker>
+  <assembly fullname="FarkleNeo" feature="System.Resources.UseSystemResourceKeys" featurevalue="true">
+    <!-- System.Resources.UseSystemResourceKeys removes resource strings and instead uses the resource key as the exception message -->
+    <resource name="Farkle.Resources.resources" action="remove" />
+    <type fullname="System.SR">
+      <method signature="System.Boolean UsingResourceKeys()" body="stub" value="true" />
+    </type>
+  </assembly>
+</linker>

--- a/src/FarkleNeo/Properties/Resources.cs
+++ b/src/FarkleNeo/Properties/Resources.cs
@@ -31,4 +31,14 @@ internal static class Resources
     }
 
     public static string Grammar_TooNewFormat => GetResourceString(nameof(Grammar_TooNewFormat));
+
+    public static string Grammar_TooOldFormat => GetResourceString(nameof(Grammar_TooOldFormat));
+
+    public static string Grammar_EgtNeoNotSupported=> GetResourceString(nameof(Grammar_EgtNeoNotSupported));
+
+    public static string Grammar_GoldParserMustConvert=> GetResourceString(nameof(Grammar_GoldParserMustConvert));
+
+    public static string Grammar_UnrecognizedFormat => GetResourceString(nameof(Grammar_UnrecognizedFormat));
+
+    public static string Grammar_Farkle7MustOpen => GetResourceString(nameof(Grammar_Farkle7MustOpen));
 }

--- a/src/FarkleNeo/Properties/Resources.cs
+++ b/src/FarkleNeo/Properties/Resources.cs
@@ -1,0 +1,34 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+using System.Globalization;
+using System.Resources;
+
+namespace Farkle;
+
+internal static class Resources
+{
+    private static readonly bool s_usingResourceKeys = AppContext.TryGetSwitch("System.Resources.UseSystemResourceKeys", out bool usingResourceKeys) && usingResourceKeys;
+
+    private static ResourceManager? s_resourceManager;
+
+    public static ResourceManager ResourceManager => s_resourceManager ??= new ResourceManager("Farkle.Resources", typeof(Resources).Assembly);
+
+    // This method is used to decide if we need to append the exception message parameters to the message when calling SR.Format.
+    // by default it returns the value of System.Resources.UseSystemResourceKeys AppContext switch or false if not specified.
+    // Native code generators can replace the value this returns based on user input at the time of native code generation.
+    // The trimming tools are also capable of replacing the value of this method when the application is being trimmed.
+    internal static bool UsingResourceKeys() => s_usingResourceKeys;
+
+    public static string GetResourceString(string resourceKey, CultureInfo? cultureInfo = null)
+    {
+        if (UsingResourceKeys())
+        {
+            return resourceKey;
+        }
+
+        return ResourceManager.GetString(resourceKey, cultureInfo)!;
+    }
+
+    public static string Grammar_TooNewFormat => GetResourceString(nameof(Grammar_TooNewFormat));
+}

--- a/src/FarkleNeo/Properties/Resources.el.resx
+++ b/src/FarkleNeo/Properties/Resources.el.resx
@@ -19,15 +19,15 @@
     <value>Η έκδοση μορφής της γραμματικής είναι πολύ παλιά για να την υποστηρίξει αυτή η έκδοση του Farkle.</value>
   </data>
   <data name="Grammar_EgtNeoNotSupported" xml:space="preserve">
-    <value>Γραμματικές από αρχεία μορφής EGTneo που παρήχθησαν από το Farkle 6.x δεν υποστηρίζονται.</value>
+    <value>Γραμματικές μορφής EGTneo που παρήχθησαν από το Farkle 6.x δεν υποστηρίζονται.</value>
   </data>
   <data name="Grammar_GoldParserMustConvert" xml:space="preserve">
-    <value>Γραμματικές από αρχεία που παρήχθησαν από το GOLD Parser πρέπει να ανοιχτούν με τη μέθοδο Grammar.CreateFromGoldParserGrammar.</value>
+    <value>Γραμματικές που παρήχθησαν από το GOLD Parser πρέπει να ανοιχτούν με τη μέθοδο Grammar.CreateFromGoldParserGrammar.</value>
   </data>
   <data name="Grammar_UnrecognizedFormat" xml:space="preserve">
     <value>Μη αναγνωρισμένη μορφή αρχείου.</value>
   </data>
   <data name="Grammar_Farkle7MustOpen" xml:space="preserve">
-    <value>Γραμματικές από αρχεία που παρήχθησαν από το Farkle 7 και πάνω πρέπει να ανοιχτούν με τη μέθοδο Grammar.Create.</value>
+    <value>Γραμματικές που παρήχθησαν από το Farkle 7 και πάνω πρέπει να ανοιχτούν με τη μέθοδο Grammar.Create.</value>
   </data>
 </root>

--- a/src/FarkleNeo/Properties/Resources.el.resx
+++ b/src/FarkleNeo/Properties/Resources.el.resx
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Grammar_TooNewFormat" xml:space="preserve">
+    <value>Η έκδοση μορφής της γραμματικής είναι πολύ νέα για να την υποστηρίξει αυτή η έκδοση του Farkle.</value>
+  </data>
+  <data name="Grammar_TooOldFormat" xml:space="preserve">
+    <value>Η έκδοση μορφής της γραμματικής είναι πολύ παλιά για να την υποστηρίξει αυτή η έκδοση του Farkle.</value>
+  </data>
+  <data name="Grammar_EgtNeoNotSupported" xml:space="preserve">
+    <value>Γραμματικές από αρχεία μορφής EGTneo που παρήχθησαν από το Farkle 6.x δεν υποστηρίζονται.</value>
+  </data>
+  <data name="Grammar_GoldParserMustConvert" xml:space="preserve">
+    <value>Γραμματικές από αρχεία που παρήχθησαν από το GOLD Parser πρέπει να ανοιχτούν με τη μέθοδο Grammar.CreateFromGoldParserGrammar.</value>
+  </data>
+  <data name="Grammar_UnrecognizedFormat" xml:space="preserve">
+    <value>Μη αναγνωρισμένη μορφή αρχείου.</value>
+  </data>
+  <data name="Grammar_Farkle7MustOpen" xml:space="preserve">
+    <value>Γραμματικές από αρχεία που παρήχθησαν από το Farkle 7 και πάνω πρέπει να ανοιχτούν με τη μέθοδο Grammar.Create.</value>
+  </data>
+</root>

--- a/src/FarkleNeo/Properties/Resources.resx
+++ b/src/FarkleNeo/Properties/Resources.resx
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Grammar_TooNewFormat" xml:space="preserve">
+    <value>The grammar's format version is too new for this version of Farkle to support.</value>
+  </data>
+</root>

--- a/src/FarkleNeo/Properties/Resources.resx
+++ b/src/FarkleNeo/Properties/Resources.resx
@@ -15,4 +15,19 @@
   <data name="Grammar_TooNewFormat" xml:space="preserve">
     <value>The grammar's format version is too new for this version of Farkle to support.</value>
   </data>
+  <data name="Grammar_TooOldFormat" xml:space="preserve">
+    <value>The grammar's format version is too old for this version of Farkle to support.</value>
+  </data>
+  <data name="Grammar_EgtNeoNotSupported" xml:space="preserve">
+    <value>EGTneo grammar files produced by Farkle 6.x are not supported.</value>
+  </data>
+  <data name="Grammar_GoldParserMustConvert" xml:space="preserve">
+    <value>Grammar files produced by GOLD Parser must be opened with the Grammar.CreateFromGoldParserGrammar method.</value>
+  </data>
+  <data name="Grammar_UnrecognizedFormat" xml:space="preserve">
+    <value>Unrecognized file format.</value>
+  </data>
+  <data name="Grammar_Farkle7MustOpen" xml:space="preserve">
+    <value>Grammar files produced by Farkle 7 and above must be opened with the Grammar.Create method.</value>
+  </data>
 </root>

--- a/tests/Farkle.Tests.CSharp/ResourcesTests.cs
+++ b/tests/Farkle.Tests.CSharp/ResourcesTests.cs
@@ -1,0 +1,24 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+namespace Farkle.Tests.CSharp;
+
+internal class ResourcesTests
+{
+    [Test]
+    public void TestAllResourcesAreDefined()
+    {
+        Assert.Multiple(() =>
+        {
+            foreach (var property in typeof(Resources).GetProperties())
+            {
+                if (property.PropertyType != typeof(string))
+                {
+                    continue;
+                }
+                var value = property.GetValue(null);
+                Assert.That(value, Is.Not.Null.And.Not.Empty);
+            }
+        });
+    }
+}

--- a/tests/Farkle.Tests.CSharp/ResourcesTests.cs
+++ b/tests/Farkle.Tests.CSharp/ResourcesTests.cs
@@ -1,6 +1,8 @@
 // Copyright © Theodore Tsirpanis and Contributors.
 // SPDX-License-Identifier: MIT
 
+using System.Globalization;
+
 namespace Farkle.Tests.CSharp;
 
 internal class ResourcesTests
@@ -10,14 +12,19 @@ internal class ResourcesTests
     {
         Assert.Multiple(() =>
         {
+            var greek = new CultureInfo("el-GR");
+            var resourceManager = Resources.ResourceManager;
             foreach (var property in typeof(Resources).GetProperties())
             {
                 if (property.PropertyType != typeof(string))
                 {
                     continue;
                 }
-                var value = property.GetValue(null);
+                var value = resourceManager.GetString(property.Name, CultureInfo.InvariantCulture);
                 Assert.That(value, Is.Not.Null.And.Not.Empty);
+                var greekValue = resourceManager.GetString(property.Name, greek);
+                Assert.That(greekValue, Is.Not.Null.And.Not.Empty.And.Not.EqualTo(value),
+                    $"String {property.Name} is not translated to Greek.");
             }
         });
     }


### PR DESCRIPTION
With this PR Farkle gets the ability to display messages that can be translated based on the current UI culture.

Not every single string will be localized; only the most likely ones the user will encounter (there's a good case that the others, like the precise reason a grammar file is invallid should not exist at all; ideally they would never get displayed).

Apart from English, Farkle will be translated to my native Greek. Community members are encouraged to add their own languages.