### PR TITLE
Always throw an `InvalidDataException` with a localizable message if converting a GOLD Parser grammar fails.

### DIFF
--- a/src/FarkleNeo/Grammars/Grammar.cs
+++ b/src/FarkleNeo/Grammars/Grammar.cs
@@ -178,11 +178,12 @@ public abstract class Grammar
         {
             data = GoldGrammarConverter.Convert(grammar);
         }
-        catch (Exception e) when (e is not (NotSupportedException or InvalidDataException))
+        catch (Exception e)
         {
-            // Let's provide a unified experience for any stray exceptions that might be thrown.
+            // Let's provide a unified experience for any exceptions
+            // that might be thrown, with a localized message.
             // We cover only Convert to avoid wrapping I/O errors.
-            throw new InvalidDataException("Failed to convert the grammar.", e);
+            throw new InvalidDataException(Resources.Grammar_FailedToConvert, e);
         }
         return Create(data);
     }

--- a/src/FarkleNeo/Properties/Resources.cs
+++ b/src/FarkleNeo/Properties/Resources.cs
@@ -41,4 +41,6 @@ internal static class Resources
     public static string Grammar_UnrecognizedFormat => GetResourceString(nameof(Grammar_UnrecognizedFormat));
 
     public static string Grammar_Farkle7MustOpen => GetResourceString(nameof(Grammar_Farkle7MustOpen));
+
+    public static string Grammar_FailedToConvert => GetResourceString(nameof(Grammar_FailedToConvert));
 }

--- a/src/FarkleNeo/Properties/Resources.el.resx
+++ b/src/FarkleNeo/Properties/Resources.el.resx
@@ -30,4 +30,7 @@
   <data name="Grammar_Farkle7MustOpen" xml:space="preserve">
     <value>Γραμματικές που παρήχθησαν από το Farkle 7 και πάνω πρέπει να ανοιχτούν με τη μέθοδο Grammar.Create.</value>
   </data>
+  <data name="Grammar_FailedToConvert" xml:space="preserve">
+    <value>Αποτυχία μετατροπής της γραμματικής.</value>
+  </data>
 </root>

--- a/src/FarkleNeo/Properties/Resources.resx
+++ b/src/FarkleNeo/Properties/Resources.resx
@@ -30,4 +30,7 @@
   <data name="Grammar_Farkle7MustOpen" xml:space="preserve">
     <value>Grammar files produced by Farkle 7 and above must be opened with the Grammar.Create method.</value>
   </data>
+  <data name="Grammar_FailedToConvert" xml:space="preserve">
+    <value>Failed to convert the grammar.</value>
+  </data>
 </root>


### PR DESCRIPTION
The conversion might throw an `InvalidOperationException` or a `NotSupportedException` and we were wrapping only the latter into the former. This is not consistent. Now all exceptions during the invocation of `GoldGrammarConverter.Convert` are wrapped in an `InvalidDataException`, which has a localizable message.

Reading the grammar file is not wrapped, they might throw `IOException`s or `NotSupportedExceptions` (if given a file with invalid signature) and it's better for consumers to directly receive these.