### PR TITLE
Set the nullable mode to annotations on .NET Standard 2.0.

### DIFF
--- a/src/FarkleNeo/FarkleNeo.csproj
+++ b/src/FarkleNeo/FarkleNeo.csproj
@@ -5,6 +5,7 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Nullable Condition="'$(TargetFramework)' == 'netstandard2.0'">annotations</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>Farkle</RootNamespace>


### PR DESCRIPTION
This should fix compiler warnings related to `Debug.Assert` not being annotated.