### PR TITLE
Parser API foundations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         # We can't use secrets in if conditions so we first put it in an environment variable.
         if: env.SONAR_TOKEN != null && runner.os == 'Linux'
         run: |
-          dotnet sonarscanner begin /k:"teo-tsirpanis_Farkle" /o:"teo-tsirpanis" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="./**/*.opencover.xml"
+          dotnet sonarscanner begin /k:"teo-tsirpanis_Farkle" /o:"teo-tsirpanis" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="./**/*.opencover.xml"
       - name: Run tests
         run: |
           dotnet run --project eng/Farkle.Build.fsproj -- -t Test
@@ -47,4 +47,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: env.SONAR_TOKEN != null && runner.os == 'Linux'
         run: |
-          dotnet sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+          dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,6 +41,7 @@
     <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
 

--- a/designs/7.0/parser-api.md
+++ b/designs/7.0/parser-api.md
@@ -336,7 +336,7 @@ namespace Farkle.Parser;
 
 public interface IParserStateContextFactory<TChar, T>
 {
-    ParserStateContext<TChar, T> Create(ParserStateContextOptions? options = null);
+    ParserStateContext<TChar, T> CreateContext(ParserStateContextOptions? options = null);
 }
 ```
 

--- a/designs/7.0/parser-api.md
+++ b/designs/7.0/parser-api.md
@@ -44,6 +44,8 @@ public struct ParserState
     public readonly Position CurrentPosition { get; }
     public readonly long TotalCharactersRead { get; }
 
+    public Position GetPositionAfter<T>(ReadOnlySpan<T> characters);
+
     public object? Context { get; init; }
     // A string describing the input source. Could be
     // used for error messages, and could be set to

--- a/designs/7.0/parser-api.md
+++ b/designs/7.0/parser-api.md
@@ -42,7 +42,7 @@ namespace Farkle.Parser;
 public struct ParserState
 {
     public readonly Position CurrentPosition { get; }
-    public readonly long TotalCharactersRead { get; }
+    public readonly long TotalCharactersConsumed { get; }
 
     public Position GetPositionAfter<T>(ReadOnlySpan<T> characters);
 
@@ -115,7 +115,7 @@ public sealed class ParserStateBox : IParserStateBox
 
 In frameworks that do not support ref fields, we have to use an interface and put the `ParserState` on the heap. A `ParserStateBox` class is provided for convenience and will be marked as obsolete on .NET 7.0+ to encourage the more efficient alternative.
 
-The `Consume` method will update the `TokenStartPosition` and `TotalCharactersRead` properties of `ParserState`. If the character type is `char` or `byte`, the column will be updated according to any CR or LF characters encountered. Otherwise only the row number will be updated.
+The `Consume` method will update the `TokenStartPosition` and `TotalCharactersConsumed` properties of `ParserState`. If the character type is `char` or `byte`, the column will be updated according to any CR or LF characters encountered. Otherwise only the row number will be updated.
 
 ### The parser
 

--- a/designs/7.0/parser-api.md
+++ b/designs/7.0/parser-api.md
@@ -93,7 +93,7 @@ public ref struct ParserInputReader<TChar>
 
     public ref ParserState State { get; }
 
-    public void AdvanceBy(int count);
+    public void Consume(int count);
 }
 
 public interface IParserStateBox
@@ -115,7 +115,7 @@ public sealed class ParserStateBox : IParserStateBox
 
 In frameworks that do not support ref fields, we have to use an interface and put the `ParserState` on the heap. A `ParserStateBox` class is provided for convenience and will be marked as obsolete on .NET 7.0+ to encourage the more efficient alternative.
 
-The `AdvanceBy` method will update the `TokenStartPosition` and `TotalCharactersRead` properties of `ParserState`. If the character type is `char` or `byte`, the column will be updated according to any CR or LF characters encountered. Otherwise only the row number will be updated.
+The `Consume` method will update the `TokenStartPosition` and `TotalCharactersRead` properties of `ParserState`. If the character type is `char` or `byte`, the column will be updated according to any CR or LF characters encountered. Otherwise only the row number will be updated.
 
 ### The parser
 

--- a/designs/7.0/parser-api.md
+++ b/designs/7.0/parser-api.md
@@ -102,7 +102,7 @@ public interface IParserStateBox
 }
 
 #if NET7_0_OR_GREATER
-[Obsolete("This type is provided for compatibility with frameworks that do not support ref fields. In .NET 7+ use a ParserState" +
+[Obsolete("This type is provided for compatibility with frameworks that do not support ref fields. In .NET 7+ use a ParserState " +
 "and pass it to the ParserInputReader's constructor by reference instead.")]
 #endif
 public sealed class ParserStateBox : IParserStateBox

--- a/designs/7.0/parser-api.md
+++ b/designs/7.0/parser-api.md
@@ -41,10 +41,10 @@ namespace Farkle.Parser;
 
 public struct ParserState
 {
-    public readonly Position CurrentPosition { get; }
+    public readonly TextPosition CurrentPosition { get; }
     public readonly long TotalCharactersConsumed { get; }
 
-    public Position GetPositionAfter<T>(ReadOnlySpan<T> characters);
+    public TextPosition GetPositionAfter<T>(ReadOnlySpan<T> characters);
 
     public object? Context { get; init; }
     // A string describing the input source. Could be
@@ -390,7 +390,7 @@ namespace Farkle.Parser.LexicalAnalysis;
 public readonly struct TokenizerResult
 {
     // Creates a TokenizerResult that indicates success.
-    public static TokenizerResult CreateSuccess(TokenSymbolHandle symbol, object? semanticValue, Position position);
+    public static TokenizerResult CreateSuccess(TokenSymbolHandle symbol, object? semanticValue, TextPosition position);
     // Creates a TokenizerResult that indicates failure.
     // The errorObject parameter will be set in the ParserCompletionState provided by the user.
     public static TokenizerResult CreateFailure(object errorObject);
@@ -400,7 +400,7 @@ public readonly struct TokenizerResult
 
     public TokenSymbolHandle Symbol { get; }
     public object? Data { get; }
-    public Position Position { get; }
+    public TextPosition Position { get; }
 }
 
 public abstract class Tokenizer<TChar>

--- a/src/FarkleNeo/FarkleNeo.csproj
+++ b/src/FarkleNeo/FarkleNeo.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Bcl.HashCode" />
     <PackageReference Include="System.Buffers" />
     <PackageReference Include="System.Memory" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="Properties/*.resx" ManifestResourceName="Farkle.%(Filename)" />

--- a/src/FarkleNeo/Parser/CharacterBufferManager.cs
+++ b/src/FarkleNeo/Parser/CharacterBufferManager.cs
@@ -1,0 +1,136 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+using System.Buffers;
+
+namespace Farkle.Parser;
+
+internal struct CharacterBufferManager<TChar>
+{
+    private TChar[] _buffer;
+    private readonly int _initialBufferSize;
+    private long _totalCharactersConsumed = 0;
+    private int _usedCharacterStart = 0, _usedCharacterEnd = 0;
+
+    public CharacterBufferManager(int initialBufferSize)
+    {
+        _initialBufferSize = initialBufferSize;
+        _buffer = ArrayPool<TChar>.Shared.Rent(initialBufferSize);
+    }
+
+    private readonly void CheckInputNotCompleted()
+    {
+        if (IsInputCompleted)
+        {
+            throw new InvalidOperationException("Input is completed.");
+        }
+    }
+
+    private void ExpandBuffer(int minRequiredCharacters)
+    {
+        int totalAvailableCharacters = _buffer.Length - _usedCharacterEnd + _usedCharacterStart;
+        if (totalAvailableCharacters > 0 && totalAvailableCharacters >= minRequiredCharacters)
+        {
+            Array.Copy(_buffer, _usedCharacterStart, _buffer, 0, _usedCharacterEnd - _usedCharacterStart);
+            _usedCharacterEnd -= _usedCharacterStart;
+            _usedCharacterStart = 0;
+            return;
+        }
+        int newSize = Math.Max(_buffer.Length * 2, _buffer.Length + minRequiredCharacters);
+        TChar[] newBuffer = ArrayPool<TChar>.Shared.Rent(newSize);
+        _buffer.CopyTo(newBuffer, _usedCharacterStart);
+        ArrayPool<TChar>.Shared.Return(_buffer);
+        _buffer = newBuffer;
+        _usedCharacterEnd -= _usedCharacterStart;
+        _usedCharacterStart = 0;
+    }
+
+    private int GetWriteBufferOffset(int sizeHint)
+    {
+        CheckInputNotCompleted();
+        sizeHint = Math.Max(sizeHint, 0);
+
+        // Check how many characters we can immediately hand out.
+        int writeBufferSize = _buffer.Length - _usedCharacterEnd;
+
+        // If we have characters and they are more than the size hint, return them.
+        if (writeBufferSize == 0 || writeBufferSize < sizeHint)
+        {
+            ExpandBuffer(sizeHint);
+        }
+
+        return _usedCharacterEnd;
+    }
+
+    public bool IsInputCompleted { get; private set; }
+
+    public readonly ReadOnlySpan<TChar> UsedCharacters =>
+        _buffer.AsSpan(_usedCharacterStart, _usedCharacterEnd - _usedCharacterStart);
+
+    public void Advance(int count)
+    {
+        CheckInputNotCompleted();
+        if ((uint)count > (uint)(_buffer.Length - _usedCharacterEnd))
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        _usedCharacterEnd += count;
+    }
+
+    public void CompleteInput()
+    {
+        CheckInputNotCompleted();
+        IsInputCompleted = true;
+    }
+
+    public Span<TChar> GetSpan(int sizeHint) =>
+        _buffer.AsSpan(GetWriteBufferOffset(sizeHint));
+
+    public Memory<TChar> GetMemory(int sizeHint) =>
+        _buffer.AsMemory(GetWriteBufferOffset(sizeHint));
+
+#if !(NETCOREAPP || NETSTANDARD2_1_OR_GREATER)
+    public ArraySegment<TChar> GetArraySegment(int sizeHint)
+    {
+        int offset = GetWriteBufferOffset(sizeHint);
+        return new ArraySegment<TChar>(_buffer, offset, _buffer.Length - offset);
+    }
+#endif
+
+    public void Reset()
+    {
+        if (_buffer is not [])
+        {
+            ArrayPool<TChar>.Shared.Return(_buffer);
+        }
+        _buffer = ArrayPool<TChar>.Shared.Rent(_initialBufferSize);
+        _totalCharactersConsumed = 0;
+        _usedCharacterStart = 0;
+        _usedCharacterEnd = 0;
+        IsInputCompleted = false;
+    }
+
+    /// <summary>
+    /// Updates the buffer manager's state after the parser has been invoked.
+    /// </summary>
+    /// <param name="totalCharactersConsumed">The value of <see cref="ParserState.TotalCharactersConsumed"/>.</param>
+    /// <param name="isCompleted">The value of <see cref="ParserCompletionState{T}.IsCompleted"/>.</param>
+    public void UpdateStateFromParser(long totalCharactersConsumed, bool isCompleted)
+    {
+        long newCharactersConsumed = totalCharactersConsumed - _totalCharactersConsumed;
+        if ((ulong)newCharactersConsumed > (ulong)_usedCharacterEnd)
+        {
+            throw new ArgumentOutOfRangeException(nameof(totalCharactersConsumed));
+        }
+        _totalCharactersConsumed = totalCharactersConsumed;
+        _usedCharacterStart += (int)newCharactersConsumed;
+
+        if (isCompleted || (_usedCharacterStart == _usedCharacterEnd && IsInputCompleted))
+        {
+            ArrayPool<TChar>.Shared.Return(_buffer);
+            _buffer = Array.Empty<TChar>();
+            IsInputCompleted = true;
+        }
+    }
+}

--- a/src/FarkleNeo/Parser/IParser.cs
+++ b/src/FarkleNeo/Parser/IParser.cs
@@ -33,7 +33,7 @@ public interface IParser<TChar,T> : IServiceProvider
     /// <para>
     /// This method must be invoked after reading new characters from the input source.
     /// To determine how many characters in the buffer should be kept, compare the
-    /// <see cref="ParserState.TotalCharactersRead"/> before and after running the parser.
+    /// <see cref="ParserState.TotalCharactersConsumed"/> before and after running the parser.
     /// </para>
     /// <para>
     /// After a result has been set to <paramref name="completionState"/> the parsing operation

--- a/src/FarkleNeo/Parser/IParser.cs
+++ b/src/FarkleNeo/Parser/IParser.cs
@@ -1,0 +1,50 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+namespace Farkle.Parser;
+
+/// <summary>
+/// Parses a series of characters and produces a result.
+/// </summary>
+/// <typeparam name="TChar">The type of characters that are parsed. Usually it is
+/// <see cref="char"/> or <see cref="byte"/> (not supported by Farkle's built-in
+/// parsers).</typeparam>
+/// <typeparam name="T">The type of result the parser produces in case of success.</typeparam>
+/// <remarks>
+/// <para>
+/// This is the base interface for Farkle's parser API and encapsulates the lexical,
+/// syntactical and semantic analysis stages. It supports high-performance parsing
+/// of text from either a contiguous buffer or from streaming input.
+/// </para>
+/// <para>
+/// Objects implementing <see cref="IParser{TChar, T}"/> must be stateless and thread-safe.
+/// </para>
+/// </remarks>
+public interface IParser<TChar,T> : IServiceProvider
+{
+    /// <summary>
+    /// Moves forward a parsing operation by parsing a block of characters.
+    /// </summary>
+    /// <param name="inputReader">Used to access the characters
+    /// and the operation's <see cref="ParserState"/>.</param>
+    /// <param name="completionState">Used to set that the operation
+    /// has completed.</param>
+    /// <remarks>
+    /// <para>
+    /// This method must be invoked after reading new characters from the input source.
+    /// To determine how many characters in the buffer should be kept, compare the
+    /// <see cref="ParserState.TotalCharactersRead"/> before and after running the parser.
+    /// </para>
+    /// <para>
+    /// After a result has been set to <paramref name="completionState"/> the parsing operation
+    /// has completed and the parser should not run again with the same parameters.
+    /// </para>
+    /// <para>
+    /// For compatibility with Farkle's default streaming input parsing mechanism, running a parser
+    /// whose <paramref name="inputReader"/>'s <see cref="ParserInputReader{TChar}.IsFinalBlock"/>
+    /// property is set to <see langword="true"/> should set a result to <paramref name="completionState"/>.
+    /// Custom parsers can support deviating from this behavior, but must do it in an opt-in fashion.
+    /// </para>
+    /// </remarks>
+    void Run(ref ParserInputReader<TChar> inputReader, ref ParserCompletionState<T> completionState);
+}

--- a/src/FarkleNeo/Parser/IParser.cs
+++ b/src/FarkleNeo/Parser/IParser.cs
@@ -17,7 +17,13 @@ namespace Farkle.Parser;
 /// of text from either a contiguous buffer or from streaming input.
 /// </para>
 /// <para>
+/// <see cref="IParser{TChar, T}"/> is the lowest-level parser API of Farkle.
+/// Higher-level APIs exist in the form of <see cref="ParserStateContext{TChar, T}"/>.
+/// </para>
+/// <para>
 /// Objects implementing <see cref="IParser{TChar, T}"/> must be stateless and thread-safe.
+/// To provide additional functionality, <see cref="IParser{TChar, T}"/> inherits from the
+/// <see cref="IServiceProvider"/> interface.
 /// </para>
 /// </remarks>
 public interface IParser<TChar,T> : IServiceProvider
@@ -40,8 +46,8 @@ public interface IParser<TChar,T> : IServiceProvider
     /// has completed and the parser should not run again with the same parameters.
     /// </para>
     /// <para>
-    /// For compatibility with Farkle's default streaming input parsing mechanism, running a parser
-    /// whose <paramref name="inputReader"/>'s <see cref="ParserInputReader{TChar}.IsFinalBlock"/>
+    /// For compatibility with Farkle's higher-level parsing APIs, running a parser whose
+    /// <paramref name="inputReader"/>'s <see cref="ParserInputReader{TChar}.IsFinalBlock"/>
     /// property is set to <see langword="true"/> should set a result to <paramref name="completionState"/>.
     /// Custom parsers can support deviating from this behavior, but must do it in an opt-in fashion.
     /// </para>

--- a/src/FarkleNeo/Parser/IParser.cs
+++ b/src/FarkleNeo/Parser/IParser.cs
@@ -4,7 +4,7 @@
 namespace Farkle.Parser;
 
 /// <summary>
-/// Parses a series of characters and produces a result.
+/// Encapsulates the logic of converting characters into meaningful objects.
 /// </summary>
 /// <typeparam name="TChar">The type of characters that are parsed. Usually it is
 /// <see cref="char"/> or <see cref="byte"/> (not supported by Farkle's built-in
@@ -18,7 +18,8 @@ namespace Farkle.Parser;
 /// </para>
 /// <para>
 /// <see cref="IParser{TChar, T}"/> is the lowest-level parser API of Farkle.
-/// Higher-level APIs exist in the form of <see cref="ParserStateContext{TChar, T}"/>.
+/// Higher-level APIs exist in the form of <see cref="ParserExtensions"/> and
+/// <see cref="ParserStateContext{TChar, T}"/>.
 /// </para>
 /// <para>
 /// Objects implementing <see cref="IParser{TChar, T}"/> must be stateless and thread-safe.

--- a/src/FarkleNeo/Parser/IParserStateBox.cs
+++ b/src/FarkleNeo/Parser/IParserStateBox.cs
@@ -1,0 +1,15 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+namespace Farkle.Parser;
+
+/// <summary>
+/// Provides a reference to a <see cref="ParserState"/>.
+/// </summary>
+public interface IParserStateBox
+{
+    /// <summary>
+    /// A reference to a <see cref="ParserState"/>.
+    /// </summary>
+    ref ParserState State { get; }
+}

--- a/src/FarkleNeo/Parser/IParserStateBox.cs
+++ b/src/FarkleNeo/Parser/IParserStateBox.cs
@@ -6,6 +6,11 @@ namespace Farkle.Parser;
 /// <summary>
 /// Provides a reference to a <see cref="ParserState"/>.
 /// </summary>
+/// <remarks>
+/// This interface is intended to be used to construct <see cref="ParserInputReader{TChar}"/>
+/// values on frameworks that do not support ref fields. It is implemented by
+/// <see cref="ParserStateBox"/> and <see cref="ParserStateContext{TChar}"/>.
+/// </remarks>
 public interface IParserStateBox
 {
     /// <summary>

--- a/src/FarkleNeo/Parser/IParserStateContextFactory.cs
+++ b/src/FarkleNeo/Parser/IParserStateContextFactory.cs
@@ -1,0 +1,27 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+namespace Farkle.Parser;
+
+/// <summary>
+/// Provides an extensibility point for <see cref="IParser{TChar, T}"/>s to create
+/// custom <see cref="ParserStateContext{TChar, T}"/>s.
+/// </summary>
+/// <typeparam name="TChar">The type of characters that are parsed. Usually it is
+/// <see cref="char"/> or <see cref="byte"/> (not supported by Farkle's built-in
+/// parsers).</typeparam>
+/// <typeparam name="T">The type of result the parser produces in case of success.</typeparam>
+/// <remarks>
+/// This is a service interface meant to be returned from <see cref="IServiceProvider.GetService"/>.
+/// User code does not need to bother with it; it is automatically considered by
+/// <see cref="ParserStateContext.Create"/>.
+/// </remarks>
+public interface IParserStateContextFactory<TChar, T>
+{
+    /// <summary>
+    /// Creates a <see cref="ParserStateContext{TChar, T}"/>.
+    /// </summary>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    public ParserStateContext<TChar, T> CreateContext(ParserStateContextOptions? options = null);
+}

--- a/src/FarkleNeo/Parser/ParserCompletionState.cs
+++ b/src/FarkleNeo/Parser/ParserCompletionState.cs
@@ -1,0 +1,86 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+namespace Farkle.Parser;
+
+/// <summary>
+/// Tracks whether a parsing operation has completed and its result.
+/// </summary>
+/// <typeparam name="T">The type of values the parsing operation returns
+/// in case of success.</typeparam>
+/// <remarks>
+/// This is a mutable value type that must be passed around by reference.
+/// </remarks>
+public struct ParserCompletionState<T>
+{
+    private ParserResult<T> _result;
+
+    /// <summary>
+    /// Whether the parsing operation has completed.
+    /// </summary>
+    /// <seealso cref="SetResult"/>
+    public bool IsCompleted { get; private set; }
+
+    /// <summary>
+    /// The result of the parsing operation.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"><see cref="IsCompleted"/>
+    /// is <see langword="false"/>.</exception>
+    public readonly ParserResult<T> Result
+    {
+        get
+        {
+            if (!IsCompleted)
+            {
+                Fail();
+            }
+            return _result;
+
+            static void Fail() => throw new InvalidOperationException(Resources.Parser_ResultAlreadySet);
+        }
+    }
+
+    /// <summary>
+    /// Completes a parsing operation.
+    /// </summary>
+    /// <param name="result">The value that will be assigned to
+    /// <see cref="Result"/>.</param>
+    /// <exception cref="InvalidOperationException">The parsing operation has
+    /// already been completed by a previous invocation of <see cref="SetResult"/>
+    /// or one of the methods in <see cref="ParserCompletionStateExtensions"/>.</exception>
+    public void SetResult(ParserResult<T> result)
+    {
+        if (IsCompleted)
+        {
+            Fail();
+        }
+        IsCompleted = true;
+        _result = result;
+
+        static void Fail() => throw new InvalidOperationException(Resources.Parser_ResultNotSet);
+    }
+}
+
+/// <summary>
+/// Provides convenience extension methods for <see cref="ParserCompletionState{T}"/>.
+/// </summary>
+public static class ParserCompletionStateExtensions
+{
+    /// <summary>
+    /// Successfully completes a parsing operation.
+    /// </summary>
+    /// <param name="state">A reference to the <see cref="ParserCompletionState{T}"/>
+    /// that will hold the result.</param>
+    /// <param name="value">The success value.</param>
+    public static void SetSuccess<T>(this ref ParserCompletionState<T> state, T value) =>
+        state.SetResult(ParserResult.CreateSuccess(value));
+
+    /// <summary>
+    /// Fails a parsing operation.
+    /// </summary>
+    /// <param name="state">A reference to the <see cref="ParserCompletionState{T}"/>
+    /// that will hold the result.</param>
+    /// <param name="error">The error value.</param>
+    public static void SetError<T>(this ref ParserCompletionState<T> state, object error) =>
+        state.SetResult(ParserResult.CreateError<T>(error));
+}

--- a/src/FarkleNeo/Parser/ParserInputReader.cs
+++ b/src/FarkleNeo/Parser/ParserInputReader.cs
@@ -1,0 +1,122 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+#if (NETCOREAPP && !NET7_0_OR_GREATER) || NETSTANDARD2_1_OR_GREATER
+using System.Runtime.InteropServices;
+#endif
+
+namespace Farkle.Parser;
+
+/// <summary>
+/// Provides an interface for a parser to read characters.
+/// </summary>
+/// <typeparam name="TChar">The type of characters.</typeparam>
+/// <remarks>
+/// This type is the replacement of the <code>Farkle.IO.CharStream</code> code of Farkle 6.
+/// Contrary to that, this is a mutable value type that must be passed around by reference.
+/// </remarks>
+public ref struct ParserInputReader<TChar>
+{
+#if NET7_0_OR_GREATER
+    private readonly ref ParserState _state;
+#elif NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+    private readonly Span<ParserState> _state;
+#else
+    private readonly IParserStateBox _stateBox;
+#endif
+
+    /// <summary>
+    /// The parser's state.
+    /// </summary>
+    public readonly ref ParserState State =>
+#if NET7_0_OR_GREATER
+        ref _state;
+#elif NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+        ref MemoryMarshal.GetReference(_state);
+#else
+        ref _stateBox.State;
+#endif
+
+    /// <summary>
+    /// The remaining available characters.
+    /// </summary>
+    public ReadOnlySpan<TChar> RemainingCharacters { get; private set; }
+
+    /// <summary>
+    /// Whether there will be no other characters available after
+    /// <see cref="RemainingCharacters"/>.
+    /// </summary>
+    public bool IsFinalBlock { get; }
+
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+    /// <summary>
+    /// Creates a <see cref="ParserInputReader{TChar}"/>.
+    /// </summary>
+    /// <param name="state">A reference to the reader's <see cref="ParserState"/>.</param>
+    /// <param name="characters">The value that will be assigned to <see cref="RemainingCharacters"/>.</param>
+    /// <param name="isFinal">The value that will be assigned to <see cref="IsFinalBlock"/>.</param>
+#if NET7_0_OR_GREATER
+    public
+#else
+    // On frameworks earlier than .NET 7 we cannot be sure that the ref
+    // safety rules are enforced and therefore cannot make it public.
+    internal
+#endif
+        ParserInputReader(ref ParserState state, ReadOnlySpan<TChar> characters, bool isFinal = true)
+    {
+#if NET7_0_OR_GREATER
+        _state = ref state;
+#else
+        _state = MemoryMarshal.CreateSpan(ref state, 1);
+#endif
+        RemainingCharacters = characters;
+        IsFinalBlock = isFinal;
+    }
+#endif
+
+    /// <summary>
+    /// Creates a <see cref="ParserInputReader{TChar}"/>.
+    /// </summary>
+    /// <param name="stateBox">An <see cref="IParserStateBox"/> containing a reference to the
+    /// reader's <see cref="ParserState"/>.</param>
+    /// <param name="characters">The value that will be assigned to <see cref="RemainingCharacters"/>.</param>
+    /// <param name="isFinal">The value that will be assigned to <see cref="IsFinalBlock"/>.</param>
+    /// <remarks>
+    /// Callers should not assume that the <paramref name="stateBox"/> instance will be
+    /// kept alive by the garbage collector on all frameworks.
+    /// </remarks>
+    public ParserInputReader(IParserStateBox stateBox, ReadOnlySpan<TChar> characters, bool isFinal = true)
+    {
+        ArgumentNullExceptionCompat.ThrowIfNull(stateBox);
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+        this = new(ref stateBox.State, characters, isFinal);
+#else
+        _stateBox = stateBox;
+        RemainingCharacters = characters;
+        IsFinalBlock = isFinal;
+#endif
+    }
+
+    /// <summary>
+    /// Consumes the first characters of <see cref="RemainingCharacters"/>
+    /// and makes them unavailable for future reads.
+    /// </summary>
+    /// <param name="count">The number of characters to consume.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is
+    /// negative or greater than the length of <see cref="RemainingCharacters"/>.</exception>
+    /// <remarks>
+    /// This method updates <see cref="RemainingCharacters"/> and the
+    /// <see cref="ParserState.CurrentPosition"/> and <see cref="ParserState.TotalCharactersRead"/>
+    /// properties of <see cref="State"/>.
+    /// </remarks>
+    /// <seealso cref="ParserState.GetPositionAfter"/>
+    public void Consume(int count)
+    {
+        if ((uint)count > (uint)RemainingCharacters.Length)
+        {
+            ThrowHelpers.ThrowArgumentOutOfRangeException(nameof(count));
+        }
+        State.Advance(RemainingCharacters[..count]);
+        RemainingCharacters = RemainingCharacters[count..];
+    }
+}

--- a/src/FarkleNeo/Parser/ParserInputReader.cs
+++ b/src/FarkleNeo/Parser/ParserInputReader.cs
@@ -106,7 +106,7 @@ public ref struct ParserInputReader<TChar>
     /// negative or greater than the length of <see cref="RemainingCharacters"/>.</exception>
     /// <remarks>
     /// This method updates <see cref="RemainingCharacters"/> and the
-    /// <see cref="ParserState.CurrentPosition"/> and <see cref="ParserState.TotalCharactersRead"/>
+    /// <see cref="ParserState.CurrentPosition"/> and <see cref="ParserState.TotalCharactersConsumed"/>
     /// properties of <see cref="State"/>.
     /// </remarks>
     /// <seealso cref="ParserState.GetPositionAfter"/>
@@ -116,7 +116,7 @@ public ref struct ParserInputReader<TChar>
         {
             ThrowHelpers.ThrowArgumentOutOfRangeException(nameof(count));
         }
-        State.Advance(RemainingCharacters[..count]);
+        State.Consume(RemainingCharacters[..count]);
         RemainingCharacters = RemainingCharacters[count..];
     }
 }

--- a/src/FarkleNeo/Parser/ParserInputReader.cs
+++ b/src/FarkleNeo/Parser/ParserInputReader.cs
@@ -8,12 +8,15 @@ using System.Runtime.InteropServices;
 namespace Farkle.Parser;
 
 /// <summary>
-/// Provides an interface for a parser to read characters.
+/// Provides an interface for a parser to read characters and alter its <see cref="ParserState"/>.
 /// </summary>
-/// <typeparam name="TChar">The type of characters.</typeparam>
+/// <typeparam name="TChar">The type of characters that are parsed. Usually it is
+/// <see cref="char"/> or <see cref="byte"/> (not supported by Farkle's built-in
+/// parsers).</typeparam>
 /// <remarks>
 /// This type is the replacement of the <code>Farkle.IO.CharStream</code> code of Farkle 6.
-/// Contrary to that, this is a mutable value type that must be passed around by reference.
+/// Contrary to that, this is a mutable <c>ref struct</c> that must be passed around by
+/// reference and cannot be placed on the heap.
 /// </remarks>
 public ref struct ParserInputReader<TChar>
 {

--- a/src/FarkleNeo/Parser/ParserInputReader.cs
+++ b/src/FarkleNeo/Parser/ParserInputReader.cs
@@ -121,5 +121,9 @@ public ref struct ParserInputReader<TChar>
         }
         State.Consume(RemainingCharacters[..count]);
         RemainingCharacters = RemainingCharacters[count..];
+        if (RemainingCharacters.IsEmpty && IsFinalBlock)
+        {
+            State.CompleteInput();
+        }
     }
 }

--- a/src/FarkleNeo/Parser/ParserState.cs
+++ b/src/FarkleNeo/Parser/ParserState.cs
@@ -67,6 +67,8 @@ public struct ParserState
         TotalCharactersConsumed += characters.Length;
     }
 
+    internal void CompleteInput() => _positionTracker.CompleteInput();
+
     /// <summary>
     /// Gets the position of the last of the given characters,
     /// assuming they start at <see cref="CurrentPosition"/>.

--- a/src/FarkleNeo/Parser/ParserState.cs
+++ b/src/FarkleNeo/Parser/ParserState.cs
@@ -27,7 +27,7 @@ public struct ParserState
     private Dictionary<object, object> _stateDictionary;
 
     /// <summary>
-    /// The position of the last character the parser has read.
+    /// The position of the last character the parser has consumed.
     /// </summary>
     /// <remarks>
     /// In transformers, this is the position of the <em>first</em>
@@ -38,10 +38,10 @@ public struct ParserState
     public readonly Position CurrentPosition => _positionTracker.Position;
 
     /// <summary>
-    /// The number of characters the parser has read.
+    /// The number of characters the parser has consumed.
     /// </summary>
     /// <seealso cref="ParserInputReader{TChar}.Consume"/>
-    public long TotalCharactersRead { get; private set; }
+    public long TotalCharactersConsumed { get; private set; }
 
     /// <summary>
     /// An implementation-specific object that can hold additional state without
@@ -61,10 +61,10 @@ public struct ParserState
     /// </remarks>
     public string? InputName { get; set; }
 
-    internal void Advance<T>(ReadOnlySpan<T> characters)
+    internal void Consume<T>(ReadOnlySpan<T> characters)
     {
         _positionTracker.Advance(characters);
-        TotalCharactersRead += characters.Length;
+        TotalCharactersConsumed += characters.Length;
     }
 
     /// <summary>

--- a/src/FarkleNeo/Parser/ParserState.cs
+++ b/src/FarkleNeo/Parser/ParserState.cs
@@ -1,0 +1,131 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+namespace Farkle.Parser;
+
+/// <summary>
+/// Contains all state of a parsing operation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <see cref="ParserState"/> contains things such as the parser's current
+/// position, and a key-value store of objects that can be used by the parser
+/// and its extensions to store arbitrary state (such as symbol tables for a
+/// programming language).
+/// </para>
+/// <para>
+/// This is a mutable value type that must be passed around by reference.
+/// </para>
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+public struct ParserState
+{
+    private PositionTracker _positionTracker;
+    private Dictionary<object, object> _stateDictionary;
+
+    /// <summary>
+    /// The position of the last character the parser has read.
+    /// </summary>
+    /// <remarks>
+    /// In transformers, this is the position of the <em>first</em>
+    /// character of the token, analogous to the
+    /// <code>ITransformerContext.TokenStartPosition</code> property of Farkle 6.
+    /// </remarks>
+    public readonly Position CurrentPosition => _positionTracker.Position;
+
+    /// <summary>
+    /// The number of characters the parser has read.
+    /// </summary>
+    public long TotalCharactersRead { get; private set; }
+
+    /// <summary>
+    /// An implementation-specific object that can hold additional state without
+    /// the allocation overhead of <see cref="SetValue"/>.
+    /// </summary>
+    /// <remarks>
+    /// The object held by this property is intended to be used by the main parser code
+    /// and not user extensions to parser.
+    /// </remarks>
+    public object? Context { get; init; }
+
+    /// <summary>
+    /// A user-provided identifier for the input being parsed.
+    /// </summary>
+    /// <remarks>
+    /// When parsing a file this could be the file's path.
+    /// </remarks>
+    public string? InputName { get; set; }
+
+    internal void Advance<T>(ReadOnlySpan<T> characters)
+    {
+        _positionTracker.Advance(characters);
+        TotalCharactersRead += characters.Length;
+    }
+
+    /// <summary>
+    /// Gets the position of the last of the given characters,
+    /// assuming they start at <see cref="CurrentPosition"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of characters.</typeparam>
+    /// <param name="characters">A <see cref="ReadOnlySpan{T}"/> of characters.</param>
+    /// <remarks>
+    /// <para>
+    /// The position's column number is incremented for each character.
+    /// If <typeparamref name="T"/> is <see cref="char"/> or <see cref="byte"/>, the
+    /// line number is incremented and the column number is reset for each CR, LF or
+    /// CRLF sequence.
+    /// </para>
+    /// <para>
+    /// CR characters at the end of <paramref name="characters"/> do not change the line number.
+    /// </para>
+    /// </remarks>
+    public readonly Position GetPositionAfter<T>(ReadOnlySpan<T> characters) =>
+        _positionTracker.GetPositionAfter(characters);
+
+    /// <summary>
+    /// Sets a value in the <see cref="ParserState"/>'s key-value dictionary.
+    /// </summary>
+    /// <param name="key">The key of the value to set.</param>
+    /// <param name="value">The value to associate with <paramref name="key"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> or
+    /// <paramref name="value"/> is <see langword="null"/>.</exception>
+    public void SetValue(object key, object value)
+    {
+        ArgumentNullExceptionCompat.ThrowIfNull(key);
+        ArgumentNullExceptionCompat.ThrowIfNull(value);
+        (_stateDictionary ??= new())[key] = value;
+    }
+
+    /// <summary>
+    /// Returns the value associated with the given key in the <see cref="ParserState"/>'s
+    /// key-value dictionary, if it exists.
+    /// </summary>
+    /// <param name="key">The key of the value to get.</param>
+    /// <param name="value">Will be assigned the value corresponding to
+    /// <paramref name="key"/>, or <see langword="null"/> if such value
+    /// does not exist.</param>
+    /// <returns>Whether the key exists in the dictionary.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    public readonly bool TryGetValue(object key, [MaybeNullWhen(false)] out object value)
+    {
+        ArgumentNullExceptionCompat.ThrowIfNull(key);
+        value = null;
+        return _stateDictionary?.TryGetValue(key, out value) ?? false;
+    }
+
+    /// <summary>
+    /// Removes the value associated with the given key from the <see cref="ParserState"/>'s
+    /// key-value dictionary.
+    /// </summary>
+    /// <param name="key">The key of a value to remove.</param>
+    /// <returns>Whether the key had existed in the dictionary.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    public bool RemoveValue(object key)
+    {
+        ArgumentNullExceptionCompat.ThrowIfNull(key);
+        return _stateDictionary?.Remove(key) ?? false;
+    }
+}

--- a/src/FarkleNeo/Parser/ParserState.cs
+++ b/src/FarkleNeo/Parser/ParserState.cs
@@ -34,11 +34,13 @@ public struct ParserState
     /// character of the token, analogous to the
     /// <code>ITransformerContext.TokenStartPosition</code> property of Farkle 6.
     /// </remarks>
+    /// <seealso cref="ParserInputReader{TChar}.Consume"/>
     public readonly Position CurrentPosition => _positionTracker.Position;
 
     /// <summary>
     /// The number of characters the parser has read.
     /// </summary>
+    /// <seealso cref="ParserInputReader{TChar}.Consume"/>
     public long TotalCharactersRead { get; private set; }
 
     /// <summary>

--- a/src/FarkleNeo/Parser/ParserState.cs
+++ b/src/FarkleNeo/Parser/ParserState.cs
@@ -35,7 +35,7 @@ public struct ParserState
     /// <code>ITransformerContext.TokenStartPosition</code> property of Farkle 6.
     /// </remarks>
     /// <seealso cref="ParserInputReader{TChar}.Consume"/>
-    public readonly Position CurrentPosition => _positionTracker.Position;
+    public readonly TextPosition CurrentPosition => _positionTracker.Position;
 
     /// <summary>
     /// The number of characters the parser has consumed.
@@ -84,7 +84,7 @@ public struct ParserState
     /// CR characters at the end of <paramref name="characters"/> do not change the line number.
     /// </para>
     /// </remarks>
-    public readonly Position GetPositionAfter<T>(ReadOnlySpan<T> characters) =>
+    public readonly TextPosition GetPositionAfter<T>(ReadOnlySpan<T> characters) =>
         _positionTracker.GetPositionAfter(characters);
 
     /// <summary>

--- a/src/FarkleNeo/Parser/ParserStateBox.cs
+++ b/src/FarkleNeo/Parser/ParserStateBox.cs
@@ -1,0 +1,30 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+namespace Farkle.Parser;
+
+/// <summary>
+/// Implements <see cref="IParserStateBox"/> trivially.
+/// </summary>
+/// <remarks>
+/// This class is intended to be used on frameworks that do not support ref fields.
+/// On frameworks that do support them, it is recommended to just declare a
+/// <see cref="ParserState"/> variable and pass it to <see cref="ParserInputReader{TChar}"/>
+/// by reference.
+/// </remarks>
+#if NET7_0_OR_GREATER
+[Obsolete("This type is provided for compatibility with frameworks that do not support ref fields. " +
+    "In .NET 7+ use a ParserState and pass it to the ParserInputReader's constructor by reference instead.")]
+#endif
+public sealed class ParserStateBox : IParserStateBox
+{
+    private ParserState _state;
+
+    /// <summary>
+    /// Creates a <see cref="ParserStateBox"/>.
+    /// </summary>
+    public ParserStateBox() {}
+
+    /// <inheritdoc/>
+    public ref ParserState State => ref _state;
+}

--- a/src/FarkleNeo/Parser/ParserStateBox.cs
+++ b/src/FarkleNeo/Parser/ParserStateBox.cs
@@ -1,6 +1,10 @@
 // Copyright © Theodore Tsirpanis and Contributors.
 // SPDX-License-Identifier: MIT
 
+#if NET7_0_OR_GREATER
+using System.ComponentModel;
+#endif
+
 namespace Farkle.Parser;
 
 /// <summary>
@@ -15,6 +19,7 @@ namespace Farkle.Parser;
 #if NET7_0_OR_GREATER
 [Obsolete("This type is provided for compatibility with frameworks that do not support ref fields. " +
     "In .NET 7+ use a ParserState and pass it to the ParserInputReader's constructor by reference instead.")]
+[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 public sealed class ParserStateBox : IParserStateBox
 {

--- a/src/FarkleNeo/Parser/ParserStateContext.cs
+++ b/src/FarkleNeo/Parser/ParserStateContext.cs
@@ -205,6 +205,12 @@ public static class ParserStateContext
     public static ParserStateContext<TChar, T> Create<TChar, T>(IParser<TChar, T> parser, ParserStateContextOptions? options = null)
     {
         ArgumentNullExceptionCompat.ThrowIfNull(parser);
+
+        if (parser.GetService(typeof(IParserStateContextFactory<TChar, T>)) is IParserStateContextFactory<TChar, T> factory)
+        {
+            return factory.CreateContext(options);
+        }
+
         return new DefaultContext<TChar, T>(parser, options);
     }
 }

--- a/src/FarkleNeo/Parser/ParserStateContext.cs
+++ b/src/FarkleNeo/Parser/ParserStateContext.cs
@@ -1,0 +1,210 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+using System.Buffers;
+
+namespace Farkle.Parser;
+
+/// <summary>
+/// Manages the lifetime of a parsing operation on streaming input.
+/// </summary>
+/// <typeparam name="TChar">The type of characters that are parsed. Usually it is
+/// <see cref="char"/> or <see cref="byte"/> (not supported by Farkle's built-in
+/// parsers).</typeparam>
+/// <remarks>
+/// <para>
+/// Parser state contexts are the intermediate-level Parser API of Farkle, sitting on
+/// top of <see cref="IParser{TChar, T}"/>. They contain the logic to parse text, to
+/// keep the parsing operation's <see cref="ParserState"/>, to manage the character
+/// buffer, and bring them all together.
+/// </para>
+/// <para>
+/// Parser state contexts implement the <see cref="IBufferWriter{TChar}"/> interface
+/// to allow writing characters in an efficient fashion. The parsing logic is automatically
+/// invoked when new characters are submitted through the <see cref="Advance"/> method,
+/// or when input ends with the <see cref="CompleteInput"/> method.
+/// </para>
+/// <para>
+/// This class cannot be inherited by user code.
+/// </para>
+/// </remarks>
+/// <seealso cref="ParserStateContext{TChar, T}"/>
+/// <seealso cref="ParserStateContext.Create"/>
+public abstract class ParserStateContext<TChar> : IParserStateBox, IBufferWriter<TChar>
+{
+    private ParserState _state;
+    private CharacterBufferManager<TChar> _bufferManager;
+
+    private protected ParserStateContext(ParserStateContextOptions? options = null)
+    {
+        _state = new() { Context = this };
+        _bufferManager = new(options?.InitialBufferSize ?? ParserStateContextOptions.DefaultInitialBufferSize);
+    }
+
+    private protected ParserInputReader<TChar> GetInputReader() =>
+        new(this, _bufferManager.UsedCharacters, _bufferManager.IsInputCompleted);
+
+    private protected void UpdateBufferState(long totalCharactersConsumed, bool isCompleted) =>
+        _bufferManager.UpdateStateFromParser(totalCharactersConsumed, isCompleted);
+
+    private protected abstract void Run();
+
+    /// <summary>
+    /// The parsing operation's state.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="ParserState.Context"/> property will be equal to
+    /// <see langword="this"/> object.
+    /// </remarks>
+    public ref ParserState State => ref _state;
+
+    /// <summary>
+    /// Whether the parsing operation has completed.
+    /// </summary>
+    public abstract bool IsCompleted { get; }
+
+    /// <summary>
+    /// Resets the <see cref="ParserStateContext{TChar}"/>, allowing it to
+    /// be reused for another parsing operation.
+    /// </summary>
+    /// <remarks>
+    /// This method cannot be overridden by user code. To provide custom resetting
+    /// logic override <see cref="ParserStateContext{TChar, T}.OnReset"/> instead.
+    /// </remarks>
+    public virtual void Reset()
+    {
+        _bufferManager.Reset();
+        _state = new() { Context = this };
+    }
+
+    /// <inheritdoc/>
+    public Memory<TChar> GetMemory(int sizeHint = 0) => _bufferManager.GetMemory(sizeHint);
+
+    /// <inheritdoc/>
+    public Span<TChar> GetSpan(int sizeHint = 0) => _bufferManager.GetSpan(sizeHint);
+
+#if !(NETCOREAPP || NETSTANDARD2_1_OR_GREATER)
+    internal ArraySegment<TChar> GetArraySegment(int sizeHint = 0) => _bufferManager.GetArraySegment(sizeHint);
+#endif
+
+    /// <inheritdoc/>
+    public void Advance(int count)
+    {
+        _bufferManager.Advance(count);
+        Run();
+    }
+
+    /// <summary>
+    /// Signals to the <see cref="ParserStateContext{TChar}"/> that no more input
+    /// </summary>
+    public void CompleteInput()
+    {
+        _bufferManager.CompleteInput();
+        Run();
+    }
+}
+
+/// <summary>
+/// Extends <see cref="ParserStateContext{TChar}"/> with the ability to return a result
+/// and some user-facing extensibility points.
+/// </summary>
+/// <typeparam name="TChar">The type of characters that are parsed. Usually it is
+/// <see cref="char"/> or <see cref="byte"/> (not supported by Farkle's built-in
+/// parsers).</typeparam>
+/// <typeparam name="T">The type of result the parser produces in case of success.</typeparam>
+/// <remarks>
+/// Unlike <see cref="ParserStateContext{TChar}"/> this class can be inherited but user code
+/// rarely needs to do it. To create a <see cref="ParserStateContext{TChar, T}"/> use the
+/// <see cref="ParserStateContext.Create"/> method.
+/// </remarks>
+public abstract class ParserStateContext<TChar, T> : ParserStateContext<TChar>
+{
+    private ParserCompletionState<T> _completionState;
+
+    /// <summary>
+    /// Creates a <see cref="ParserStateContext{TChar, T}"/>.
+    /// </summary>
+    /// <param name="options">Options to configure the context. Optional.</param>
+    protected ParserStateContext(ParserStateContextOptions? options = null) : base(options) { }
+
+    /// <inheritdoc/>
+    public sealed override bool IsCompleted => _completionState.IsCompleted;
+
+    /// <summary>
+    /// The result of the parsing operation.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"><see cref="IsCompleted"/>
+    /// is <see langword="false"/>.</exception>
+    /// <seealso cref="IsCompleted"/>
+    public ParserResult<T> Result => _completionState.Result;
+
+    /// <inheritdoc/>
+    public sealed override void Reset()
+    {
+        base.Reset();
+        _completionState = default;
+        OnReset();
+    }
+
+    private protected sealed override void Run()
+    {
+        try
+        {
+            ParserInputReader<TChar> inputReader = GetInputReader();
+            Run(ref inputReader, ref _completionState);
+        }
+        finally
+        {
+            UpdateBufferState(State.TotalCharactersConsumed, _completionState.IsCompleted);
+        }
+    }
+
+    /// <summary>
+    /// Provides an extensibility point for the <see cref="ParserStateContext{TChar, T}"/>'s
+    /// resetting logic. This method gets called by <see cref="Reset"/>.
+    /// </summary>
+    protected virtual void OnReset() { }
+
+    /// <summary>
+    /// Invokes the parsing logic of the <see cref="ParserStateContext{TChar, T}"/>.
+    /// </summary>
+    /// <param name="inputReader">Used to access the characters
+    /// and the operation's <see cref="ParserState"/>.</param>
+    /// <param name="completionState">Used to set that the operation
+    /// has completed.</param>
+    /// <seealso cref="IParser{TChar, T}.Run"/>
+    protected abstract void Run(ref ParserInputReader<TChar> inputReader, ref ParserCompletionState<T> completionState);
+}
+
+/// <summary>
+/// Provides methods to create <see cref="ParserStateContext{TChar, T}"/> objects.
+/// </summary>
+public static class ParserStateContext
+{
+    private sealed class DefaultContext<TChar, T> : ParserStateContext<TChar, T>
+    {
+        private readonly IParser<TChar, T> _parser;
+
+        public DefaultContext(IParser<TChar, T> parser, ParserStateContextOptions? options) : base(options) =>
+            _parser = parser;
+
+        protected override void Run(ref ParserInputReader<TChar> inputReader, ref ParserCompletionState<T> completionState) =>
+            _parser.Run(ref inputReader, ref completionState);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="ParserStateContext{TChar, T}"/> from an <see cref="IParser{TChar, T}"/>.
+    /// </summary>
+    /// <typeparam name="TChar">The type of characters that are parsed. Usually it is
+    /// <see cref="char"/> or <see cref="byte"/> (not supported by Farkle's built-in
+    /// parsers).</typeparam>
+    /// <typeparam name="T">The type of result the parser produces in case of success.</typeparam>
+    /// <param name="parser">The <see cref="IParser{TChar, T}"/> to use.</param>
+    /// <param name="options">Options to configure the context. Optional.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="parser"/> is <see langword="null"/>.</exception>
+    public static ParserStateContext<TChar, T> Create<TChar, T>(IParser<TChar, T> parser, ParserStateContextOptions? options = null)
+    {
+        ArgumentNullExceptionCompat.ThrowIfNull(parser);
+        return new DefaultContext<TChar, T>(parser, options);
+    }
+}

--- a/src/FarkleNeo/Parser/ParserStateContextOptions.cs
+++ b/src/FarkleNeo/Parser/ParserStateContextOptions.cs
@@ -1,0 +1,20 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+namespace Farkle.Parser;
+
+/// <summary>
+/// Provides options to configure a <see cref="ParserStateContext{TChar}"/>.
+/// </summary>
+public sealed class ParserStateContextOptions
+{
+    internal const int DefaultInitialBufferSize = 512;
+
+    /// <summary>
+    /// The initial size of the buffer used to store the input characters.
+    /// </summary>
+    /// <remarks>
+    /// Currently defaults to 512 characters. This value may change in the future.
+    /// </remarks>
+    public int InitialBufferSize { get; init; } = DefaultInitialBufferSize;
+}

--- a/src/FarkleNeo/Parser/PositionTracker.cs
+++ b/src/FarkleNeo/Parser/PositionTracker.cs
@@ -1,0 +1,132 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+using System.Runtime.CompilerServices;
+
+namespace Farkle.Parser;
+
+/// <summary>
+/// Tracks the current position of text being parsed.
+/// </summary>
+/// <remarks>
+/// This class has to be stateful to correctly handle CR and CRLF line endings.
+/// Both CR and LF move the <see cref="Position"/> to the next line, but an LF after
+/// a CR does not. Therefore besides the position we also store whether the last
+/// character we saw is a CR, because the CR and the LF might be submitted separately.
+/// </remarks>
+internal struct PositionTracker
+{
+    private bool _lastSeenCr;
+
+    /// <summary>
+    /// The current position.
+    /// </summary>
+    public Position Position { get; private set; }
+
+    private static Position AdvanceCore<T>(Position position, ReadOnlySpan<T> span, T cr, T lf)
+        where T : struct, IEquatable<T>
+    {
+        int line = position.Line, column = position.Column;
+        while (true)
+        {
+            switch (span.IndexOfAny(lf, cr))
+            {
+                case -1:
+                    return Position.Create0(line, column + span.Length);
+                case int nlPos:
+                    if (span[nlPos].Equals(lf) || span[nlPos].Equals(cr) && nlPos < span.Length)
+                    {
+                        line++;
+                        column = 0;
+                    }
+                    span = span[(nlPos + 1)..];
+                    break;
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe Position Advance<T>(Position position, ReadOnlySpan<T> span)
+    {
+        if (typeof(T) == typeof(char))
+        {
+            return AdvanceCore(position, *(ReadOnlySpan<char>*)&span, '\r', '\n');
+        }
+        if (typeof(T) == typeof(byte))
+        {
+            return AdvanceCore(position, *(ReadOnlySpan<byte>*)&span, (byte)'\r', (byte)'\n');
+        }
+        return Position.Create0(position.Line, position.Column + span.Length);
+    }
+
+    /// <summary>
+    /// Gets the position of the last of the given characters,
+    /// assuming they start at <see cref="Position"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of characters.</typeparam>
+    /// <param name="span">A <see cref="ReadOnlySpan{T}"/> of characters.</param>
+    /// <remarks>
+    /// <para>
+    /// The position's column number is incremented for each character.
+    /// If <typeparamref name="T"/> is <see cref="char"/> or <see cref="byte"/>, the
+    /// line number is incremented and the column number is reset for each CR, LF or
+    /// CRLF sequence.
+    /// </para>
+    /// <para>
+    /// CR characters at the end of <paramref name="span"/> do not change the line number.
+    /// </para>
+    /// </remarks>
+    /// <seealso cref="Advance{T}(ReadOnlySpan{T})"/>
+    public readonly Position GetPositionAfter<T>(ReadOnlySpan<T> span)
+    {
+        Position pos = Position;
+        if (!span.IsEmpty)
+        {
+            if (_lastSeenCr)
+            {
+                if ((typeof(T) == typeof(char) && (char)(object)span[0]! != '\n')
+                    || (typeof(T) == typeof(byte) && (byte)(object)span[0]! != (byte)'\n'))
+                {
+                    pos = pos.NextLine();
+                }
+            }
+            pos = Advance(pos, span);
+        }
+        return pos;
+    }
+
+    /// <summary>
+    /// Advances <see cref="Position"/> to the position of the last of the given characters.
+    /// </summary>
+    /// <typeparam name="T">The type of characters.</typeparam>
+    /// <param name="span">A <see cref="ReadOnlySpan{T}"/> of characters.</param>
+    /// <remarks>
+    /// This method remembers whether the last character in <paramref name="span"/> is a CR.
+    /// </remarks>
+    /// <seealso cref="GetPositionAfter"/>
+    public void Advance<T>(ReadOnlySpan<T> span)
+    {
+        if (!span.IsEmpty)
+        {
+            Position = GetPositionAfter(span);
+            _lastSeenCr = (typeof(T) == typeof(char) && (char)(object)span[^1]! == '\r')
+                || (typeof(T) == typeof(byte) && (byte)(object)span[^1]! == (byte)'\r');
+        }
+    }
+
+    /// <summary>
+    /// Marks the end of input.
+    /// </summary>
+    /// <remarks>
+    /// The line number of <see cref="Position"/> is incremented if the last
+    /// character submitted in <see cref="Advance{T}(ReadOnlySpan{T})"/> is a CR.
+    /// </remarks>
+    public void CompleteInput()
+    {
+        if (_lastSeenCr)
+        {
+            _lastSeenCr = false;
+            Position = Position.NextLine();
+        }
+    }
+}

--- a/src/FarkleNeo/Parser/PositionTracker.cs
+++ b/src/FarkleNeo/Parser/PositionTracker.cs
@@ -44,13 +44,11 @@ internal struct PositionTracker
         TextPosition pos = Position;
         if (!span.IsEmpty)
         {
-            if (_lastSeenCr)
+            if (_lastSeenCr
+                && ((typeof(T) == typeof(char) && (char)(object)span[0]! != '\n')
+                || (typeof(T) == typeof(byte) && (byte)(object)span[0]! != (byte)'\n')))
             {
-                if ((typeof(T) == typeof(char) && (char)(object)span[0]! != '\n')
-                    || (typeof(T) == typeof(byte) && (byte)(object)span[0]! != (byte)'\n'))
-                {
-                    pos = pos.NextLine();
-                }
+                pos = pos.NextLine();
             }
             pos = pos.Advance(span);
         }

--- a/src/FarkleNeo/Parser/PositionTracker.cs
+++ b/src/FarkleNeo/Parser/PositionTracker.cs
@@ -21,9 +21,9 @@ internal struct PositionTracker
     /// <summary>
     /// The current position.
     /// </summary>
-    public Position Position { get; private set; }
+    public TextPosition Position { get; private set; }
 
-    private static Position AdvanceCore<T>(Position position, ReadOnlySpan<T> span, T cr, T lf)
+    private static TextPosition AdvanceCore<T>(TextPosition position, ReadOnlySpan<T> span, T cr, T lf)
         where T : struct, IEquatable<T>
     {
         int line = position.Line, column = position.Column;
@@ -32,7 +32,7 @@ internal struct PositionTracker
             switch (span.IndexOfAny(lf, cr))
             {
                 case -1:
-                    return Position.Create0(line, column + span.Length);
+                    return TextPosition.Create0(line, column + span.Length);
                 case int nlPos:
                     if (span[nlPos].Equals(lf) || span[nlPos].Equals(cr) && nlPos < span.Length)
                     {
@@ -46,7 +46,7 @@ internal struct PositionTracker
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static unsafe Position Advance<T>(Position position, ReadOnlySpan<T> span)
+    private static unsafe TextPosition Advance<T>(TextPosition position, ReadOnlySpan<T> span)
     {
         if (typeof(T) == typeof(char))
         {
@@ -56,7 +56,7 @@ internal struct PositionTracker
         {
             return AdvanceCore(position, *(ReadOnlySpan<byte>*)&span, (byte)'\r', (byte)'\n');
         }
-        return Position.Create0(position.Line, position.Column + span.Length);
+        return TextPosition.Create0(position.Line, position.Column + span.Length);
     }
 
     /// <summary>
@@ -77,9 +77,9 @@ internal struct PositionTracker
     /// </para>
     /// </remarks>
     /// <seealso cref="Advance{T}(ReadOnlySpan{T})"/>
-    public readonly Position GetPositionAfter<T>(ReadOnlySpan<T> span)
+    public readonly TextPosition GetPositionAfter<T>(ReadOnlySpan<T> span)
     {
-        Position pos = Position;
+        TextPosition pos = Position;
         if (!span.IsEmpty)
         {
             if (_lastSeenCr)

--- a/src/FarkleNeo/Parser/PositionTracker.cs
+++ b/src/FarkleNeo/Parser/PositionTracker.cs
@@ -1,8 +1,6 @@
 // Copyright © Theodore Tsirpanis and Contributors.
 // SPDX-License-Identifier: MIT
 
-using System.Runtime.CompilerServices;
-
 namespace Farkle.Parser;
 
 /// <summary>
@@ -22,42 +20,6 @@ internal struct PositionTracker
     /// The current position.
     /// </summary>
     public TextPosition Position { get; private set; }
-
-    private static TextPosition AdvanceCore<T>(TextPosition position, ReadOnlySpan<T> span, T cr, T lf)
-        where T : struct, IEquatable<T>
-    {
-        int line = position.Line, column = position.Column;
-        while (true)
-        {
-            switch (span.IndexOfAny(lf, cr))
-            {
-                case -1:
-                    return TextPosition.Create0(line, column + span.Length);
-                case int nlPos:
-                    if (span[nlPos].Equals(lf) || span[nlPos].Equals(cr) && nlPos < span.Length)
-                    {
-                        line++;
-                        column = 0;
-                    }
-                    span = span[(nlPos + 1)..];
-                    break;
-            }
-        }
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static unsafe TextPosition Advance<T>(TextPosition position, ReadOnlySpan<T> span)
-    {
-        if (typeof(T) == typeof(char))
-        {
-            return AdvanceCore(position, *(ReadOnlySpan<char>*)&span, '\r', '\n');
-        }
-        if (typeof(T) == typeof(byte))
-        {
-            return AdvanceCore(position, *(ReadOnlySpan<byte>*)&span, (byte)'\r', (byte)'\n');
-        }
-        return TextPosition.Create0(position.Line, position.Column + span.Length);
-    }
 
     /// <summary>
     /// Gets the position of the last of the given characters,
@@ -90,7 +52,7 @@ internal struct PositionTracker
                     pos = pos.NextLine();
                 }
             }
-            pos = Advance(pos, span);
+            pos = pos.Advance(span);
         }
         return pos;
     }

--- a/src/FarkleNeo/ParserExtensions.cs
+++ b/src/FarkleNeo/ParserExtensions.cs
@@ -1,0 +1,251 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+using Farkle.Parser;
+
+namespace Farkle;
+
+/// <summary>
+/// Provides extension methods on <see cref="IParser{TChar, T}"/>
+/// to easily parse text from various sources.
+/// </summary>
+/// <remarks>
+/// This is the highest-level parser API of Farkle. It is recommended
+/// for most use cases.
+/// </remarks>
+public static class ParserExtensions
+{
+    private static ParserResult<T> ParseCore<TChar, T>(this IParser<TChar, T> parser, ReadOnlySpan<TChar> s)
+    {
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+        ParserState state = new();
+        ParserInputReader<TChar> inputReader = new(ref state, s, true);
+#else
+        ParserStateBox stateBox = new();
+        ParserInputReader<TChar> inputReader = new(stateBox, s, true);
+#endif
+        ParserCompletionState<T> completionState = new();
+        parser.Run(ref inputReader, ref completionState);
+        return completionState.Result;
+    }
+
+    private static ParserResult<T> RunContext<T>(ParserStateContext<char, T> context, TextReader reader, bool keepReaderOpen)
+    {
+        try
+        {
+            while (!context.IsCompleted)
+            {
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+                int read = reader.Read(context.GetSpan());
+#else
+                ArraySegment<char> segment = context.GetArraySegment();
+                int read = reader.Read(segment.Array, segment.Offset, segment.Count);
+#endif
+                if (read == 0)
+                {
+                    context.CompleteInput();
+                    break;
+                }
+                context.Advance(read);
+            }
+            return context.Result;
+        }
+        finally
+        {
+            if (!keepReaderOpen)
+            {
+                reader.Dispose();
+            }
+        }
+    }
+
+    private static async ValueTask<ParserResult<T>> RunContextAsync<T>(ParserStateContext<char, T> context, TextReader reader, bool keepReaderOpen, CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!context.IsCompleted)
+            {
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+                int read = await reader.ReadAsync(context.GetMemory(), cancellationToken);
+#else
+                ArraySegment<char> segment = context.GetArraySegment();
+                int read = await (cancellationToken.IsCancellationRequested ?
+                    Task.FromCanceled<int>(cancellationToken) :
+                    reader.ReadAsync(segment.Array, segment.Offset, segment.Count));
+#endif
+                if (read == 0)
+                {
+                    context.CompleteInput();
+                    break;
+                }
+                context.Advance(read);
+            }
+            return context.Result;
+        }
+        finally
+        {
+            if (!keepReaderOpen)
+            {
+                reader.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parses a <see cref="ReadOnlySpan{TChar}"/>.
+    /// </summary>
+    /// <typeparam name="TChar">The type of characters.</typeparam>
+    /// <typeparam name="T">The type of result the parser produces in case of success.</typeparam>
+    /// <param name="parser">The <see cref="IParser{TChar, T}"/> to use.</param>
+    /// <param name="s">The span to parse.</param>
+    /// <returns>A <see cref="ParserResult{T}"/> containing the result of the parsing operation.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="parser"/> is <see langword="null"/>.</exception>
+    public static ParserResult<T> Parse<TChar, T>(this IParser<TChar, T> parser, ReadOnlySpan<TChar> s)
+    {
+        ArgumentNullExceptionCompat.ThrowIfNull(parser);
+        return parser.ParseCore(s);
+    }
+
+    /// <summary>
+    /// Parses a <see cref="string"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of result the parser produces in case of success.</typeparam>
+    /// <param name="parser">The <see cref="IParser{TChar, T}"/> to use.</param>
+    /// <param name="s">The string to parse.</param>
+    /// <returns>A <see cref="ParserResult{T}"/> containing the result of the parsing operation.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="parser"/> or <paramref name="s"/> is
+    /// <see langword="null"/>.</exception>
+    public static ParserResult<T> Parse<T>(this IParser<char, T> parser, string s)
+    {
+        ArgumentNullExceptionCompat.ThrowIfNull(parser);
+        ArgumentNullExceptionCompat.ThrowIfNull(s);
+        return parser.ParseCore(s.AsSpan());
+    }
+
+    /// <summary>
+    /// Parses a stream of characters read from a <see cref="TextReader"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of result the parser produces in case of success.</typeparam>
+    /// <param name="parser">The <see cref="IParser{TChar, T}"/> to use.</param>
+    /// <param name="reader">The <see cref="TextReader"/> to read the characters from.</param>
+    /// <returns>A <see cref="ParserResult{T}"/> containing the result of the parsing operation.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="parser"/> or <paramref name="reader"/> is
+    /// <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <paramref name="reader"/> will be read from until it ends or the parsing operation fails.
+    /// <paramref name="reader"/> will not be automatically disposed.
+    /// </remarks>
+    public static ParserResult<T> Parse<T>(this IParser<char, T> parser, TextReader reader)
+    {
+        ArgumentNullExceptionCompat.ThrowIfNull(parser);
+        ArgumentNullExceptionCompat.ThrowIfNull(reader);
+
+        ParserStateContext<char, T> context = ParserStateContext.Create(parser);
+        return RunContext(context, reader, keepReaderOpen: true);
+    }
+
+    /// <summary>
+    /// Parses the content of a file. This method wraps <see cref="Parse{T}(IParser{char, T}, TextReader)"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of result the parser produces in case of success.</typeparam>
+    /// <param name="parser">The <see cref="IParser{TChar, T}"/> to use.</param>
+    /// <param name="path">The path to the file to parse.</param>
+    /// <returns>A <see cref="ParserResult{T}"/> containing the result of the parsing operation.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="parser"/> or <paramref name="path"/> is
+    /// <see langword="null"/>.</exception>
+    /// <remarks>
+    /// The file will be read from until it ends or until the parsing operation fails.
+    /// </remarks>
+    public static ParserResult<T> ParseFile<T>(this IParser<char, T> parser, string path)
+    {
+        ArgumentNullExceptionCompat.ThrowIfNull(parser);
+        ArgumentNullExceptionCompat.ThrowIfNull(path);
+
+        ParserStateContext<char, T> context = ParserStateContext.Create(parser);
+        context.State.InputName = path;
+        // We don't need buffering in the FileStream; both the context and the StreamReader have.
+        TextReader reader = new StreamReader(new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 1));
+        return RunContext(context, reader, keepReaderOpen: false);
+    }
+
+    /// <summary>
+    /// Asynchronously parses a stream of characters read from a <see cref="TextReader"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of result the parser produces in case of success.</typeparam>
+    /// <param name="parser">The <see cref="IParser{TChar, T}"/> to use.</param>
+    /// <param name="reader">The <see cref="TextReader"/> to read the characters from.</param>
+    /// <param name="cancellationToken">Used to cancel the parsing operation. Optional.</param>
+    /// <returns>A <see cref="ValueTask{TResult}"/> that will return a <see cref="ParserResult{T}"/>
+    /// containing the result of the parsing operation.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="parser"/> or <paramref name="reader"/> is
+    /// <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// <paramref name="reader"/> will be read from until it ends or the parsing operation fails.
+    /// <paramref name="reader"/> will not be automatically disposed.
+    /// </para>
+    /// <para>
+    /// On frameworks not compatible with .NET Standard 2.1, cancelling the operation will not
+    /// have effect until the next time the characters are read. This is due to
+    /// <see cref="TextReader"/> not supporting passing a <see cref="CancellationToken"/> to its
+    /// <c>ReadAsync</c> method.
+    /// </para>
+    /// </remarks>
+    public static ValueTask<ParserResult<T>> ParseAsync<T>(this IParser<char, T> parser, TextReader reader,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullExceptionCompat.ThrowIfNull(parser);
+        ArgumentNullExceptionCompat.ThrowIfNull(reader);
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            // ValueTask.FromCanceled is not available in all frameworks.
+            // We use Task.FromCanceled and wrap it in a ValueTask, which
+            // is equivalent.
+            return new(Task.FromCanceled<ParserResult<T>>(cancellationToken));
+        }
+
+        ParserStateContext<char, T> context = ParserStateContext.Create(parser);
+        return RunContextAsync(context, reader, keepReaderOpen: true, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Asynchronously parses the content of a file. This method wraps <see cref="ParseAsync"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of result the parser produces in case of success.</typeparam>
+    /// <param name="parser">The <see cref="IParser{TChar, T}"/> to use.</param>
+    /// <param name="path">The path to the file to parse.</param>
+    /// <param name="cancellationToken">Used to cancel the parsing operation. Optional.</param>
+    /// <returns>A <see cref="ValueTask{TResult}"/> that will return a <see cref="ParserResult{T}"/>
+    /// containing the result of the parsing operation.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="parser"/> or <paramref name="path"/> is
+    /// <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// The file will be read from until it ends or until the parsing operation fails.
+    /// </para>
+    /// <para>
+    /// On frameworks not compatible with .NET Standard 2.1, cancelling the operation will not
+    /// have effect until the next time the characters are read. This is due to
+    /// <see cref="TextReader"/> not supporting passing a <see cref="CancellationToken"/> to its
+    /// <c>ReadAsync</c> method.
+    /// </para>
+    /// </remarks>
+    public static ValueTask<ParserResult<T>> ParseFileAsync<T>(this IParser<char, T> parser, string path,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullExceptionCompat.ThrowIfNull(parser);
+        ArgumentNullExceptionCompat.ThrowIfNull(path);
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return new(Task.FromCanceled<ParserResult<T>>(cancellationToken));
+        }
+
+        ParserStateContext<char, T> context = ParserStateContext.Create(parser);
+        context.State.InputName = path;
+        // We don't need buffering in the FileStream; both the context and the StreamReader have.
+        TextReader reader = new StreamReader(new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 1, true));
+        return RunContextAsync(context, reader, keepReaderOpen: false, cancellationToken: cancellationToken);
+    }
+}

--- a/src/FarkleNeo/ParserResult.cs
+++ b/src/FarkleNeo/ParserResult.cs
@@ -1,0 +1,89 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Farkle;
+
+/// <summary>
+/// Represents the result of a parsing operation. It contains a
+/// <typeparamref name="T"/> in case of success or an <see cref="object"/>
+/// in case of failure.
+/// </summary>
+/// <typeparam name="T">The type of values held by successful parser
+/// results.</typeparam>
+public readonly struct ParserResult<T>
+{
+    private readonly T _value;
+
+    internal ParserResult(T value, object? error)
+    {
+        _value = value;
+        Error = error;
+    }
+
+    /// <summary>
+    /// Whether the <see cref="ParserResult{T}"/> represents success.
+    /// </summary>
+    /// <seealso cref="Value"/>
+    [MemberNotNullWhen(false, nameof(Error))]
+    public bool IsSuccess => Error is null;
+
+    /// <summary>
+    /// Whether the <see cref="ParserResult{T}"/> represents failure.
+    /// </summary>
+    /// <seealso cref="Error"/>
+    [MemberNotNullWhen(true, nameof(Error))]
+    public bool IsError => Error is not null;
+
+    /// <summary>
+    /// The <see cref="ParserResult{T}"/>'s success value.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"><see cref="IsSuccess"/>
+    /// is <see langword="false"/>.</exception>
+    public T Value
+    {
+        get
+        {
+            if (!IsSuccess)
+            {
+                ThrowHelpers.ThrowInvalidOperationException(Error.ToString());
+            }
+            return _value;
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="ParserResult{T}"/>'s error value.
+    /// </summary>
+    /// <returns>
+    /// An implementation-defined <see cref="object"/> that describes what went
+    /// wrong with the parsing operation, or <see langword="null"/> if the parsing
+    /// operation has succeeded.
+    /// </returns>
+    public object? Error { get; }
+}
+
+/// <summary>
+/// Provides methods to create <see cref="ParserResult{T}"/> values.
+/// </summary>
+public static class ParserResult
+{
+    /// <summary>
+    /// Creates a successful <see cref="ParserResult{T}"/>.
+    /// </summary>
+    /// <param name="value">The result's success value.</param>
+    public static ParserResult<T> CreateSuccess<T>(T value) => new(value, null);
+
+    /// <summary>
+    /// Creates a failed <see cref="ParserResult{T}"/>.
+    /// </summary>
+    /// <param name="error">The result's error value.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="error"/>
+    /// is <see langword="null"/>.</exception>
+    public static ParserResult<T> CreateError<T>(object error)
+    {
+        ArgumentNullExceptionCompat.ThrowIfNull(error);
+        return new(default!, error);
+    }
+}

--- a/src/FarkleNeo/Position.cs
+++ b/src/FarkleNeo/Position.cs
@@ -1,0 +1,98 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Farkle;
+
+/// <summary>
+/// Represents the position of a character in text.
+/// </summary>
+public readonly struct Position : IEquatable<Position>
+#if NET6_0_OR_GREATER
+    , ISpanFormattable
+#endif
+{
+    private readonly int _line, _column;
+
+    private Position(int line, int column)
+    {
+        _line = line;
+        _column = column;
+    }
+
+    /// <summary>
+    /// A <see cref="Position"/> that points to the start of text.
+    /// </summary>
+    public Position Initial => default;
+
+    /// <summary>
+    /// The line number of the <see cref="Position"/>.
+    /// </summary>
+    public int Line => _line + 1;
+    /// <summary>
+    /// The column number of the <see cref="Position"/>.
+    /// </summary>
+    public int Column => _column + 1;
+
+    /// <summary>
+    /// Creates a <see cref="Position"/> from zero-based coordinates.
+    /// </summary>
+    /// <param name="line">The line coordinate, starting from zero.</param>
+    /// <param name="column">The column coordinate, starting from zero.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="line"/>
+    /// or <paramref name="column"/> are smaller than zero.</exception>
+    public static Position Create0(int line, int column)
+    {
+        ArgumentOutOfRangeExceptionCompat.ThrowIfNegative(line);
+        ArgumentOutOfRangeExceptionCompat.ThrowIfNegative(column);
+        return new(line, column);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="Position"/> from one-based coordinates.
+    /// </summary>
+    /// <param name="line">The line coordinate, starting from one.</param>
+    /// <param name="column">The column coordinate, starting from one.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="line"/>
+    /// or <paramref name="column"/> are smaller than one.</exception>
+    public static Position Create1(int line, int column) =>
+        Create0(line - 1, column - 1);
+
+    /// <summary>
+    /// Checks two <see cref="Position"/>s for equality.
+    /// </summary>
+    /// <param name="other">The other position.</param>
+    /// <returns>Whether <see langword="this"/> and <paramref name="other"/>
+    /// have the same <see cref="Line"/> and <see cref="Column"/> values.</returns>
+    public bool Equals(Position other) =>
+        Line == other.Line && Column == other.Column;
+
+    private string ToString(IFormatProvider? formatProvider) =>
+#if NET6_0_OR_GREATER
+        string.Create(formatProvider, stackalloc char[32], $"({Line}, {Column})");
+#else
+        formatProvider is null ? $"({Line}, {Column})" : ((FormattableString)$"({Line}, {Column})").ToString(formatProvider);
+#endif
+
+#if NET6_0_OR_GREATER
+    string IFormattable.ToString(string? format, IFormatProvider? formatProvider) =>
+        ToString(formatProvider);
+
+    bool ISpanFormattable.TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider) =>
+        destination.TryWrite(provider, $"({Line}, {Column})", out charsWritten);
+#endif
+
+    /// <inheritdoc/>
+    public override bool Equals([NotNullWhen(true)] object? obj) =>
+        obj is Position pos && Equals(pos);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => HashCode.Combine(Line, Column);
+
+    /// <summary>
+    /// Formats the <see cref="Position"/> to a string.
+    /// </summary>
+    /// <returns>The string <c>(<see cref="Line"/>, <see cref="Column"/>)</c></returns>
+    public override string ToString() => ToString(null);
+}

--- a/src/FarkleNeo/Position.cs
+++ b/src/FarkleNeo/Position.cs
@@ -59,6 +59,8 @@ public readonly struct Position : IEquatable<Position>
     public static Position Create1(int line, int column) =>
         Create0(line - 1, column - 1);
 
+    internal Position NextLine() => new(_line + 1, 0);
+
     /// <summary>
     /// Checks two <see cref="Position"/>s for equality.
     /// </summary>

--- a/src/FarkleNeo/Position.cs
+++ b/src/FarkleNeo/Position.cs
@@ -24,7 +24,7 @@ public readonly struct Position : IEquatable<Position>
     /// <summary>
     /// A <see cref="Position"/> that points to the start of text.
     /// </summary>
-    public Position Initial => default;
+    public static Position Initial => default;
 
     /// <summary>
     /// The line number of the <see cref="Position"/>.
@@ -61,15 +61,6 @@ public readonly struct Position : IEquatable<Position>
 
     internal Position NextLine() => new(_line + 1, 0);
 
-    /// <summary>
-    /// Checks two <see cref="Position"/>s for equality.
-    /// </summary>
-    /// <param name="other">The other position.</param>
-    /// <returns>Whether <see langword="this"/> and <paramref name="other"/>
-    /// have the same <see cref="Line"/> and <see cref="Column"/> values.</returns>
-    public bool Equals(Position other) =>
-        Line == other.Line && Column == other.Column;
-
     private string ToString(IFormatProvider? formatProvider) =>
 #if NET6_0_OR_GREATER
         string.Create(formatProvider, stackalloc char[32], $"({Line}, {Column})");
@@ -85,9 +76,34 @@ public readonly struct Position : IEquatable<Position>
         destination.TryWrite(provider, $"({Line}, {Column})", out charsWritten);
 #endif
 
+    /// <summary>
+    /// Checks two <see cref="Position"/>s for equality.
+    /// </summary>
+    /// <param name="other">The other position.</param>
+    /// <returns>Whether <see langword="this"/> and <paramref name="other"/>
+    /// have the same <see cref="Line"/> and <see cref="Column"/> values.</returns>
+    public bool Equals(Position other) =>
+        Line == other.Line && Column == other.Column;
+
     /// <inheritdoc/>
     public override bool Equals([NotNullWhen(true)] object? obj) =>
         obj is Position pos && Equals(pos);
+
+    /// <summary>
+    /// Implements the equality operator for <see cref="Position"/>.
+    /// </summary>
+    /// <param name="left">The first position.</param>
+    /// <param name="right">The second position.</param>
+    /// <returns>Whether the two positions are equal.</returns>
+    public static bool operator ==(Position left, Position right) => left.Equals(right);
+
+    /// <summary>
+    /// Implements the inequality operator for <see cref="Position"/>.
+    /// </summary>
+    /// <param name="left">The first position.</param>
+    /// <param name="right">The second position.</param>
+    /// <returns>Whether the two positions are not equal.</returns>
+    public static bool operator !=(Position left, Position right) => !left.Equals(right);
 
     /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(Line, Column);

--- a/src/FarkleNeo/Properties/Resources.cs
+++ b/src/FarkleNeo/Properties/Resources.cs
@@ -43,4 +43,8 @@ internal static class Resources
     public static string Grammar_Farkle7MustOpen => GetResourceString(nameof(Grammar_Farkle7MustOpen));
 
     public static string Grammar_FailedToConvert => GetResourceString(nameof(Grammar_FailedToConvert));
+
+    public static string Parser_ResultAlreadySet => GetResourceString(nameof(Parser_ResultAlreadySet));
+
+    public static string Parser_ResultNotSet => GetResourceString(nameof(Parser_ResultNotSet));
 }

--- a/src/FarkleNeo/Properties/Resources.el.resx
+++ b/src/FarkleNeo/Properties/Resources.el.resx
@@ -33,4 +33,10 @@
   <data name="Grammar_FailedToConvert" xml:space="preserve">
     <value>Αποτυχία μετατροπής της γραμματικής.</value>
   </data>
+  <data name="Parser_ResultAlreadySet" xml:space="preserve">
+    <value>Η συντακτική ανάλυση έχει ήδη θέσει ένα αποτέλεσμα.</value>
+  </data>
+  <data name="Parser_ResultNotSet" xml:space="preserve">
+    <value>Η συντακτική ανάλυση δεν έχει θέσει ακόμα ένα αποτέλεσμα.</value>
+  </data>
 </root>

--- a/src/FarkleNeo/Properties/Resources.resx
+++ b/src/FarkleNeo/Properties/Resources.resx
@@ -33,4 +33,10 @@
   <data name="Grammar_FailedToConvert" xml:space="preserve">
     <value>Failed to convert the grammar.</value>
   </data>
+  <data name="Parser_ResultAlreadySet" xml:space="preserve">
+    <value>The parsing operation has already set a result.</value>
+  </data>
+  <data name="Parser_ResultNotSet" xml:space="preserve">
+    <value>The parsing operation has not yet set a result.</value>
+  </data>
 </root>

--- a/src/FarkleNeo/TextPosition.cs
+++ b/src/FarkleNeo/TextPosition.cs
@@ -8,41 +8,41 @@ namespace Farkle;
 /// <summary>
 /// Represents the position of a character in text.
 /// </summary>
-public readonly struct Position : IEquatable<Position>
+public readonly struct TextPosition : IEquatable<TextPosition>
 #if NET6_0_OR_GREATER
     , ISpanFormattable
 #endif
 {
     private readonly int _line, _column;
 
-    private Position(int line, int column)
+    private TextPosition(int line, int column)
     {
         _line = line;
         _column = column;
     }
 
     /// <summary>
-    /// A <see cref="Position"/> that points to the start of text.
+    /// A <see cref="TextPosition"/> that points to the start of text.
     /// </summary>
-    public static Position Initial => default;
+    public static TextPosition Initial => default;
 
     /// <summary>
-    /// The line number of the <see cref="Position"/>.
+    /// The line number of the <see cref="TextPosition"/>.
     /// </summary>
     public int Line => _line + 1;
     /// <summary>
-    /// The column number of the <see cref="Position"/>.
+    /// The column number of the <see cref="TextPosition"/>.
     /// </summary>
     public int Column => _column + 1;
 
     /// <summary>
-    /// Creates a <see cref="Position"/> from zero-based coordinates.
+    /// Creates a <see cref="TextPosition"/> from zero-based coordinates.
     /// </summary>
     /// <param name="line">The line coordinate, starting from zero.</param>
     /// <param name="column">The column coordinate, starting from zero.</param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="line"/>
     /// or <paramref name="column"/> are smaller than zero.</exception>
-    public static Position Create0(int line, int column)
+    public static TextPosition Create0(int line, int column)
     {
         ArgumentOutOfRangeExceptionCompat.ThrowIfNegative(line);
         ArgumentOutOfRangeExceptionCompat.ThrowIfNegative(column);
@@ -50,16 +50,16 @@ public readonly struct Position : IEquatable<Position>
     }
 
     /// <summary>
-    /// Creates a <see cref="Position"/> from one-based coordinates.
+    /// Creates a <see cref="TextPosition"/> from one-based coordinates.
     /// </summary>
     /// <param name="line">The line coordinate, starting from one.</param>
     /// <param name="column">The column coordinate, starting from one.</param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="line"/>
     /// or <paramref name="column"/> are smaller than one.</exception>
-    public static Position Create1(int line, int column) =>
+    public static TextPosition Create1(int line, int column) =>
         Create0(line - 1, column - 1);
 
-    internal Position NextLine() => new(_line + 1, 0);
+    internal TextPosition NextLine() => new(_line + 1, 0);
 
     private string ToString(IFormatProvider? formatProvider) =>
 #if NET6_0_OR_GREATER
@@ -77,39 +77,39 @@ public readonly struct Position : IEquatable<Position>
 #endif
 
     /// <summary>
-    /// Checks two <see cref="Position"/>s for equality.
+    /// Checks two <see cref="TextPosition"/>s for equality.
     /// </summary>
     /// <param name="other">The other position.</param>
     /// <returns>Whether <see langword="this"/> and <paramref name="other"/>
     /// have the same <see cref="Line"/> and <see cref="Column"/> values.</returns>
-    public bool Equals(Position other) =>
+    public bool Equals(TextPosition other) =>
         Line == other.Line && Column == other.Column;
 
     /// <inheritdoc/>
     public override bool Equals([NotNullWhen(true)] object? obj) =>
-        obj is Position pos && Equals(pos);
+        obj is TextPosition pos && Equals(pos);
 
     /// <summary>
-    /// Implements the equality operator for <see cref="Position"/>.
+    /// Implements the equality operator for <see cref="TextPosition"/>.
     /// </summary>
     /// <param name="left">The first position.</param>
     /// <param name="right">The second position.</param>
     /// <returns>Whether the two positions are equal.</returns>
-    public static bool operator ==(Position left, Position right) => left.Equals(right);
+    public static bool operator ==(TextPosition left, TextPosition right) => left.Equals(right);
 
     /// <summary>
-    /// Implements the inequality operator for <see cref="Position"/>.
+    /// Implements the inequality operator for <see cref="TextPosition"/>.
     /// </summary>
     /// <param name="left">The first position.</param>
     /// <param name="right">The second position.</param>
     /// <returns>Whether the two positions are not equal.</returns>
-    public static bool operator !=(Position left, Position right) => !left.Equals(right);
+    public static bool operator !=(TextPosition left, TextPosition right) => !left.Equals(right);
 
     /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(Line, Column);
 
     /// <summary>
-    /// Formats the <see cref="Position"/> to a string.
+    /// Formats the <see cref="TextPosition"/> to a string.
     /// </summary>
     /// <returns>The string <c>(<see cref="Line"/>, <see cref="Column"/>)</c></returns>
     public override string ToString() => ToString(null);

--- a/tests/Farkle.Tests.CSharp/PositionTrackerTests.cs
+++ b/tests/Farkle.Tests.CSharp/PositionTrackerTests.cs
@@ -1,0 +1,52 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+using Farkle.Parser;
+
+namespace Farkle.Tests.CSharp;
+
+internal class PositionTrackerTests
+{
+    public static void TestLineEndings<T>(ReadOnlySpan<T> text)
+    {
+        TextPosition[] expectedPositions = {
+            TextPosition.Initial,
+            TextPosition.Create1(2,2),
+            TextPosition.Create1(3,1),
+            TextPosition.Create1(3,1),
+            TextPosition.Create1(4,1)
+        };
+
+        TextPosition[] actualPositions = new TextPosition[text.Length];
+
+        PositionTracker tracker = new();
+        for (int i = 0; i < actualPositions.Length; i++)
+        {
+            tracker.Advance(text.Slice(i, 1));
+            actualPositions[i] = tracker.Position;
+        }
+
+        Assert.That(actualPositions, Is.EqualTo(expectedPositions));
+    }
+
+    [Test]
+    public void TestLineEndingsChar() => TestLineEndings("\r \n\r\n".AsSpan());
+
+    [Test]
+    public void TestLineEndingsByte() => TestLineEndings("\r \n\r\n"u8);
+
+    public void TestFinalCr<T>(ReadOnlySpan<T> text)
+    {
+        PositionTracker tracker = new();
+        tracker.Advance(text);
+        Assert.That(tracker.Position, Is.EqualTo(TextPosition.Create1(1, 2)));
+        tracker.CompleteInput();
+        Assert.That(tracker.Position, Is.EqualTo(TextPosition.Create1(2, 1)));
+    }
+
+    [Test]
+    public void TestFinalCrChar() => TestFinalCr(" \r".AsSpan());
+
+    [Test]
+    public void TestFinalCrByte() => TestFinalCr(" \r"u8);
+}

--- a/tests/Farkle.Tests.CSharp/PositionTrackerTests.cs
+++ b/tests/Farkle.Tests.CSharp/PositionTrackerTests.cs
@@ -7,7 +7,7 @@ namespace Farkle.Tests.CSharp;
 
 internal class PositionTrackerTests
 {
-    public static void TestLineEndings<T>(ReadOnlySpan<T> text)
+    private static void TestLineEndings<T>(ReadOnlySpan<T> text)
     {
         TextPosition[] expectedPositions = {
             TextPosition.Initial,
@@ -35,7 +35,7 @@ internal class PositionTrackerTests
     [Test]
     public void TestLineEndingsByte() => TestLineEndings("\r \n\r\n"u8);
 
-    public void TestFinalCr<T>(ReadOnlySpan<T> text)
+    private static void TestFinalCr<T>(ReadOnlySpan<T> text)
     {
         PositionTracker tracker = new();
         tracker.Advance(text);


### PR DESCRIPTION
This PR implements the foundational types of Farkle 7's Parser API. It adds all types in the Parser API design document, except for `CharParser`, `IGrammarProvider`, and the semantic and lexical analysis APIs.