### PR TITLE
Run fsdocs in strict mode.

### DIFF
--- a/eng/build.fs
+++ b/eng/build.fs
@@ -326,6 +326,7 @@ let generateDocs doWatch isRelease =
         "--output"
         docsOutput
         "--properties"
+        "--strict"
         $"TargetFramework={DocumentationAssemblyFramework}"
         if not isRelease then
             "--parameters"


### PR DESCRIPTION
For some time (I guess since the update to .NET 8) fsdocs has been silently failing to produce reference documentation. This PR will make it fail explicitly.