### PR TITLE
Add an API to load a grammar from a file.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,7 +38,7 @@
     <PackageVersion Include="Sigourney.Build" Version="0.4.1" />
     <PackageVersion Include="Sigourney" Version="0.4.1" />
     <PackageVersion Include="System.Buffers" Version="4.5.1" />
-    <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0-rc.2.23479.6" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/performance/Farkle.Benchmarks.CSharp/GrammarReaderBenchmark.cs
+++ b/performance/Farkle.Benchmarks.CSharp/GrammarReaderBenchmark.cs
@@ -8,6 +8,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using Farkle.Grammars;
 using System.Collections.Immutable;
+using System.Runtime.InteropServices;
 using Farkle6 = farkle6::Farkle;
 
 namespace Farkle.Benchmarks;
@@ -26,7 +27,7 @@ public class GrammarReaderBenchmark
     {
         Egt = File.ReadAllBytes($"resources/{Grammars}.egt");
         EgtNeo = File.ReadAllBytes($"resources/{Grammars}.egtn");
-        Farkle7Grammar = File.ReadAllBytes($"resources/{Grammars}.grammar.dat").ToImmutableArray();
+        Farkle7Grammar = ImmutableCollectionsMarshal.AsImmutableArray(File.ReadAllBytes($"resources/{Grammars}.grammar.dat"));
     }
 
     [BenchmarkCategory("Read"), Benchmark(Baseline = true)]

--- a/performance/Farkle.Performance.Profiling/Program.cs
+++ b/performance/Farkle.Performance.Profiling/Program.cs
@@ -23,7 +23,7 @@ internal static class Program
     private static readonly Farkle6.RuntimeFarkle<object> _syntaxCheck =
         Farkle6.RuntimeFarkle<object>.Create(Farkle6.Grammar.EGT.ReadFromFile(Farkle6GrammarPath), Farkle6.PostProcessors.SyntaxChecker);
     private static readonly CharParser<object> _syntaxCheck7 =
-        CharParser.CreateSyntaxChecker(Grammars.Grammar.Create(File.ReadAllBytes(Farkle7GrammarPath)));
+        CharParser.CreateSyntaxChecker(Grammar.CreateFromFile(Farkle7GrammarPath));
     private static readonly Farkle6.Parser.Tokenizer _tokenizer =
         new Farkle6.Parser.DefaultTokenizer(_syntaxCheck.GetGrammar());
     private static readonly Farkle.Parser.Tokenizers.Tokenizer<char> _tokenizer7 =

--- a/src/FarkleNeo/Grammars/Grammar.cs
+++ b/src/FarkleNeo/Grammars/Grammar.cs
@@ -6,6 +6,7 @@ using Farkle.Grammars.StateMachines;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 
 namespace Farkle.Grammars;
 
@@ -160,6 +161,21 @@ public abstract class Grammar : IGrammarProvider
             ThrowHelpers.ThrowArgumentNullException(nameof(grammarData));
         }
         return new ManagedMemoryGrammar(grammarData);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="Grammar"/> from a file. The entire file is read in memory.
+    /// </summary>
+    /// <param name="path">The path to the file.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="path"/> is
+    /// <see langword="null"/>.</exception>
+    public static Grammar CreateFromFile(string path)
+    {
+        ArgumentNullExceptionCompat.ThrowIfNull(path);
+        // TODO-PERF: Consider reading a part of the file at the beginning
+        // to validate the header, and then reading all of it.
+        ImmutableArray<byte> data = ImmutableCollectionsMarshal.AsImmutableArray(File.ReadAllBytes(path));
+        return Create(data);
     }
 
     /// <summary>

--- a/tests/Farkle.Tests.CSharp/GrammarTests.cs
+++ b/tests/Farkle.Tests.CSharp/GrammarTests.cs
@@ -63,9 +63,8 @@ internal class GrammarTests
     public void TestReadGrammar(string grammarFile)
     {
         var filePath = TestUtilities.GetResourceFile(grammarFile);
-        var buffer = File.ReadAllBytes(filePath);
 
-        var grammar = Grammar.Create(buffer);
+        var grammar = Grammar.CreateFromFile(filePath);
 
         Assert.Multiple(() =>
         {

--- a/tests/Farkle.Tests.CSharp/TestUtilities.cs
+++ b/tests/Farkle.Tests.CSharp/TestUtilities.cs
@@ -14,5 +14,5 @@ public static class TestUtilities
     public static string GetResourceFile(string fileName) => Path.Combine(ResourcePath, fileName);
 
     public static Grammar LoadGrammarFromResource(string fileName) =>
-        Grammar.Create(File.ReadAllBytes(GetResourceFile(fileName)));
+        Grammar.CreateFromFile(GetResourceFile(fileName));
 }


### PR DESCRIPTION
I was originally not going to add it, but changed my mind since it is more efficient than `Grammar.Create(File.ReadAllBytes("path"))`[^1], and I had to write it quite some times.

[^1]: That call to `Grammar.Create` takes a span, and allocates another array. What this new API does is use the newly introduced `ImmutableCollectionsMarshal.AsImmutableArray` and create the grammar from the immutable array, which does not make a copy.