### PR TITLE
Validate the header before reading a large grammar file.

### DIFF
--- a/src/FarkleNeo/Compatibility/StreamCompat.cs
+++ b/src/FarkleNeo/Compatibility/StreamCompat.cs
@@ -1,0 +1,46 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if (NETCOREAPP || NETSTANDARD2_1_OR_GREATER) && !NET7_0_OR_GREATER
+namespace System.IO
+{
+    internal static class StreamCompat
+    {
+        public static int ReadAtLeast(this Stream stream, Span<byte> buffer, int minimumLength)
+        {
+            int totalRead = 0;
+            while (totalRead < minimumLength)
+            {
+                int n = stream.Read(buffer[totalRead..]);
+                if (n == 0)
+                {
+                    break;
+                }
+                totalRead += n;
+            }
+            return totalRead;
+        }
+
+        public static void ReadExactly(this Stream stream, Span<byte> buffer)
+        {
+            while (!buffer.IsEmpty)
+            {
+                int n = stream.Read(buffer);
+                if (n == 0)
+                {
+                    break;
+                }
+                buffer = buffer[n..];
+            }
+
+            if (!buffer.IsEmpty)
+            {
+                throw new EndOfStreamException();
+            }
+        }
+    }
+}
+#endif

--- a/src/FarkleNeo/Grammars/GrammarHeader.cs
+++ b/src/FarkleNeo/Grammars/GrammarHeader.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using Farkle.Buffers;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static Farkle.Grammars.GrammarConstants;
 
@@ -14,6 +15,22 @@ internal readonly struct GrammarHeader(ushort versionMajor, ushort versionMinor,
     /// The size of the version-independent part of a Farkle grammar header.
     /// </summary>
     private const int VersionIndependentHeaderSize = sizeof(ulong) + 2 * sizeof(ushort);
+
+    /// <summary>
+    /// The smallest number of bytes necessary to read from
+    /// the start of a Farkle grammar file to determine its type.
+    /// </summary>
+    public static int MinHeaderDisambiguatorSize => EgtNeoHeader.Length;
+
+#if DEBUG
+    static GrammarHeader()
+    {
+        Debug.Assert(MinHeaderDisambiguatorSize >= VersionIndependentHeaderSize);
+        Debug.Assert(MinHeaderDisambiguatorSize >= CgtHeader.Length);
+        Debug.Assert(MinHeaderDisambiguatorSize >= EgtHeader.Length);
+        Debug.Assert(MinHeaderDisambiguatorSize >= EgtNeoHeader.Length);
+    }
+#endif
 
     public ushort VersionMajor { get; private init; } = versionMajor;
     public ushort VersionMinor { get; private init; } = versionMinor;


### PR DESCRIPTION
Saves some allocations if the file to load is not a grammar file. This is done only on modern frameworks.