### PR TITLE
Add string formatting methods to `ParserResult`.

### DIFF
--- a/tests/Farkle.Tests.CSharp/ParserResultTests.cs
+++ b/tests/Farkle.Tests.CSharp/ParserResultTests.cs
@@ -1,0 +1,19 @@
+// Copyright 2023 Theodore Tsirpanis.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Farkle.Tests.CSharp;
+
+internal class ParserResultTests
+{
+    [Test]
+    public void TestToString()
+    {
+        ParserResult<int> success = ParserResult.CreateSuccess(42);
+        ParserResult<int> failure = ParserResult.CreateError<int>("error");
+        Assert.Multiple(() =>
+        {
+            Assert.That(success.ToString(), Is.EqualTo("42"));
+            Assert.That(failure.ToString(), Is.EqualTo("error"));
+        });
+    }
+}


### PR DESCRIPTION
They simply call `ToString()` or its equivalents on the success or error value.