### PR TITLE
Fix build script failures on Linux.

### DIFF
--- a/eng/build.fs
+++ b/eng/build.fs
@@ -19,6 +19,7 @@ open Fake.Tools
 open Scriban
 open System
 open System.IO
+open System.Reflection
 open System.Text.RegularExpressions
 
 // Information about the project are used
@@ -481,6 +482,12 @@ let initTargets() =
 
 [<EntryPoint>]
 let main argv =
+    // Workaround for failures on Linux.
+    Assembly.Load("StructuredLogger")
+        .GetType("Microsoft.Build.Logging.StructuredLogger.Strings", true)
+        .GetMethod("Initialize")
+        .Invoke(null, [|"en-US"|])
+    |> ignore
     argv
     |> Array.toList
     |> Context.FakeExecutionContext.Create false "build.fs"


### PR DESCRIPTION
We are experiencing failures similar to KirillOsenkov/MSBuildStructuredLog#736. This PR provides a simple workaround.