### PR TITLE
Optimize reading invalid EGT files.

### DIFF
--- a/src/FarkleNeo/Grammars/GoldParser/GrammarBinaryReader.cs
+++ b/src/FarkleNeo/Grammars/GoldParser/GrammarBinaryReader.cs
@@ -19,7 +19,7 @@ internal sealed class GrammarBinaryReader
     public GrammarBinaryReader(Stream input)
     {
         _reader = new BinaryReader(input);
-        Header = ReadNullTerminatedString();
+        Header = ReadNullTerminatedString(isHeader: true);
     }
 
     public string Header { get; }


### PR DESCRIPTION
There has been a special mode of `GrammarBinaryReader.ReadNullTerminatedString` for reading the header that imposes a limit of 100 characters, but this has not been actually used due to oversight.