### PR TITLE
Add `ParserApplicationException`.

### DIFF
--- a/src/FarkleNeo/Farkle.fs
+++ b/src/FarkleNeo/Farkle.fs
@@ -532,6 +532,15 @@ module internal GrammarBuilderOperators =
     /// error on building. Useful for recursive productions.
     let inline nonterminalU name = Nonterminal.CreateUntyped name
 
+    /// Raises a `ParserApplicationException` with the given errror object.
+    /// This exception will be caught by Farkle and gracefully fail the parsing operation.
+    /// Use this function when the error might occur under normal circumstances
+    /// (such as an unknown identifier name in a programming language).
+    let error msg = Farkle.ParserApplicationException msg |> raise
+
+    /// Variant of `error` that takes a format string.
+    let errorf fmt = Printf.ksprintf error fmt
+
     /// Creates a `IGrammarSymbol&lt;'T&gt;` that represents
     /// a nonterminal with the given name and productions.
     let inline (||=) name (productions: #seq<_>) =

--- a/src/FarkleNeo/Parser/Implementation/ParserUtilities.cs
+++ b/src/FarkleNeo/Parser/Implementation/ParserUtilities.cs
@@ -65,12 +65,16 @@ internal static class ParserUtilities
         return builder.ToImmutable();
     }
 
-    internal static object SupplyParserStateInfo(object diagnostic, ImmutableArray<string?> expectedTokenNames, int parserState)
-        => diagnostic switch
+    internal static object SupplyParserStateInfo(object diagnostic, Grammar grammar, LrStateMachine lr, int parserState)
+    {
+        return diagnostic switch
         {
-            IParserStateInfoSupplier x => x.WithParserStateInfo(expectedTokenNames, parserState),
+            IParserStateInfoSupplier x => x.WithParserStateInfo(GetExpectedTokenNames(), parserState),
             ParserDiagnostic { Message: IParserStateInfoSupplier x, Position: var position } =>
-                new ParserDiagnostic(position, x.WithParserStateInfo(expectedTokenNames, parserState)),
+                new ParserDiagnostic(position, x.WithParserStateInfo(GetExpectedTokenNames(), parserState)),
             _ => diagnostic
         };
+
+        ImmutableArray<string?> GetExpectedTokenNames() => GetExpectedSymbols(grammar, lr[parserState]);
+    }
 }

--- a/src/FarkleNeo/Parser/Tokenizers/Tokenizer.cs
+++ b/src/FarkleNeo/Parser/Tokenizers/Tokenizer.cs
@@ -23,6 +23,7 @@ public abstract class Tokenizer<TChar>
     /// Whether the tokenizer does not need to be wrapped in a tokenizer chain.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// To always support suspension, even standalone tokenizers are wrapped in a
     /// tokenizer chain, leading to an extra layer of indirection. By setting this
     /// property to <see langword="true"/>, Farkle does not wrap the tokenizer if
@@ -32,6 +33,12 @@ public abstract class Tokenizer<TChar>
     /// never suspend. An exception to this is when the tokenizer suspends by calling
     /// <see cref="TokenizerExtensions.SuspendTokenizer{TChar}(ref ParserInputReader{TChar}, Tokenizer{TChar})"/>
     /// with a resumption point of <see langword="this"/>.
+    /// </para>
+    /// <para>
+    /// Additionally, tokenizers that set this property to <see langword="true"/> must
+    /// handle thrown exceptions of type <sep cref="ParserApplicationException"/> and
+    /// translate them to error <see cref="TokenizerResult"/>s.
+    /// </para>
     /// </remarks>
     internal bool CanSkipChainedTokenizerWrapping { get; private protected init; }
 

--- a/src/FarkleNeo/ParserApplicationException.cs
+++ b/src/FarkleNeo/ParserApplicationException.cs
@@ -1,0 +1,64 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+using Farkle.Diagnostics;
+using Farkle.Parser;
+
+namespace Farkle;
+
+/// <summary>
+/// Represents an application-specific error that occurred during parsing.
+/// </summary>
+/// <remarks>
+/// Farkle will catch this exception when thrown from a semantic provider
+/// or tokenizer, and gracefully fail the parsing process with a
+/// user-specified error object.
+/// </remarks>
+public sealed class ParserApplicationException : Exception
+{
+    /// <summary>
+    /// Whether the parser's position should be included in the error object.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If set to <see langword="true"/>, Farkle will wrap <see cref="Error"/> in
+    /// a <see cref="ParserDiagnostic"/> with the parser's <see cref="ParserState.CurrentPosition"/>
+    /// at the time of the error, and return it to the user.
+    /// </para>
+    /// <para>
+    /// This property is ignored if <see cref="Error"/> is already a <see cref="ParserDiagnostic"/>.
+    /// </para>
+    /// </remarks>
+    public bool AutoSetPosition { get; }
+
+    /// <summary>
+    /// The error object that will be returned from the parser.
+    /// </summary>
+    public object Error { get; }
+
+    internal object GetErrorObject(TextPosition position) => Error switch {
+        ParserDiagnostic => Error,
+        _ when AutoSetPosition => new ParserDiagnostic(position, Error),
+        _ => Error
+    };
+
+    /// <summary>
+    /// Returns the message of the <see cref="ParserApplicationException"/>.
+    /// It is the string representation of the <see cref="Error"/> property.
+    /// </summary>
+    public override string Message => Error.ToString() ?? "";
+
+    /// <summary>
+    /// Creates a <see cref="ParserApplicationException"/>.
+    /// </summary>
+    /// <param name="error">The error object that will be returned to the parser.</param>
+    /// <param name="autoSetPosition">Whether the parser's position should be included in
+    /// the error object. Defaults to <see langword="true"/>.</param>
+    public ParserApplicationException(object error, bool autoSetPosition = true)
+    {
+        // Farkle requires error objects to not be null, but throwing
+        // another exception while creating an exception is not very helpful.
+        Error = error ?? "<undefined>";
+        AutoSetPosition = autoSetPosition;
+    }
+}

--- a/tests/Farkle.Tests/GrammarBuilderTests.fs
+++ b/tests/Farkle.Tests/GrammarBuilderTests.fs
@@ -8,6 +8,7 @@ module Farkle.Tests.GrammarBuilderTests
 open Expecto
 open Farkle
 open Farkle.Builder
+open Farkle.Diagnostics
 open Farkle.Parser
 open FsCheck
 open System
@@ -73,6 +74,24 @@ let tests = testList "Grammar builder tests" [
     testProperty "Farkle can properly read floating-point numbers" (fun (NormalFloat num) ->
         let runtime = Terminals.float "Floating-point" |> GrammarBuilder.build
         Expect.equal (runtime.Parse(string num)) (ParserResult.CreateSuccess num) "Parsing an unsigned integer failed")
+
+    test "Arithmetic overflows when parsing integers do not cause an exception" {
+        // Add a space at the beginning to test position propagation.
+        let testString = " 99999999999999999999"
+        let doTest (builder: string -> IGrammarSymbol<_>) =
+            let parser = (builder "Number").Build()
+            Expect.isFalse (parser.IsFailing) "Building failed"
+            let result = CharParser.parseString parser testString |> ParserResult.toResult
+            let error = Expect.wantError result "Parsing should have failed"
+            match error with
+            | ParserDiagnostic(pos, :? string) -> Expect.equal pos.Column 2 "Parsing failed at a different position"
+            | _ -> failwith "Parsing did not fail with a string"
+
+        doTest Terminals.int
+        doTest Terminals.int64
+        doTest Terminals.uint32
+        doTest Terminals.uint64
+    }
 
     test "IGrammarSymbols, productions, and transformers are covariant" {
         let symbol = terminal "x" (T(fun _ _ -> "")) (Regex.string "x")


### PR DESCRIPTION
This PR adds an exception type that gets caught by Farkle during lecical or semantic analysis, and gracefully fails the parsing operation. Such feature already exists in Farkle 6.