### PR TITLE
Add APIs to build specific artifacts from a grammar builder.

### DIFF
--- a/src/FarkleNeo/Builder/BuilderArtifacts.cs
+++ b/src/FarkleNeo/Builder/BuilderArtifacts.cs
@@ -1,0 +1,52 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+using Farkle.Grammars;
+using Farkle.Parser.Semantics;
+using Farkle.Parser.Tokenizers;
+
+namespace Farkle.Builder;
+
+/// <summary>
+/// Represents the possible artifacts that the builder can produce.
+/// </summary>
+/// <seealso cref="BuilderResult{T}"/>
+[Flags]
+public enum BuilderArtifacts {
+    /// <summary>
+    /// Nothing gets built.
+    /// </summary>
+    None = 0,
+    /// <summary>
+    /// Builds a <see cref="Grammar"/> with no state machines.
+    /// </summary>
+    /// <seealso cref="BuilderResult{T}.Grammar"/>
+    GrammarSummary = 1,
+    /// <summary>
+    /// Builds a <see cref="Grammar"/> with an LR state machine.
+    /// </summary>
+    /// <seealso cref="BuilderResult{T}.Grammar"/>
+    GrammarLrStateMachine = 2,
+    /// <summary>
+    /// Builds a <see cref="Grammar"/> with a DFA on <see cref="char"/>.
+    /// </summary>
+    /// <seealso cref="BuilderResult{T}.Grammar"/>
+    GrammarDfaOnChar = 4,
+    /// <summary>
+    /// Builds a <see cref="Tokenizer{Char}"/> on <see cref="char"/>.
+    /// </summary>
+    /// <seealso cref="BuilderResult{T}.TokenizerOnChar"/>
+    TokenizerOnChar = 8,
+    /// <summary>
+    /// Builds an <see cref="ISemanticProvider{Char, T}"/> on <see cref="char"/>.
+    /// </summary>
+    /// <seealso cref="BuilderResult{T}.SemanticProviderOnChar"/>
+    // We could also add TokenSemanticProviderOnChar and ProductionSemanticProvider because the latter
+    // is character-agnostic but that seems very excessive.
+    SemanticProviderOnChar = 16,
+    /// <summary>
+    /// Builds a <see cref="CharParser{T}"/>.
+    /// </summary>
+    /// <seealso cref="BuilderResult{T}.CharParser"/>
+    CharParser = 32
+}

--- a/src/FarkleNeo/Builder/BuilderResult.cs
+++ b/src/FarkleNeo/Builder/BuilderResult.cs
@@ -1,0 +1,44 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+using Farkle.Grammars;
+using Farkle.Parser.Semantics;
+using Farkle.Parser.Tokenizers;
+
+namespace Farkle.Builder;
+
+/// <summary>
+/// Represents the result of a builder operation.
+/// </summary>
+/// <typeparam name="T">The type of objects the parser will produce in case of success.</typeparam>
+/// <remarks>
+/// All properties of this class are nullable and they are populated based on the <see cref="BuilderArtifacts"/>
+/// that were requested when building.
+/// </remarks>
+/// <seealso cref="GrammarBuilderExtensions.Build{T}(IGrammarBuilder{T}, BuilderArtifacts, BuilderOptions?)"/>
+/// <seealso cref="GrammarBuilderExtensions.BuildSyntaxCheck(IGrammarBuilder, BuilderArtifacts, BuilderOptions?)"/>
+/// <seealso cref="GrammarBuilderExtensions.BuildSyntaxCheck{T}(IGrammarBuilder, BuilderArtifacts, BuilderOptions?)"/>
+public sealed class BuilderResult<T>
+{
+    internal BuilderResult() { }
+
+    internal CharParser<T> GetCharParserOrThrow() =>
+        CharParser ?? throw new InvalidOperationException("The CharParser is not available.");
+
+    /// <summary>
+    /// The built <see cref="Grammar"/>.
+    /// </summary>
+    public Grammar? Grammar { get; internal init; }
+    /// <summary>
+    /// The built <see cref="ISemanticProvider{TChar, T}"/> on <see cref="char"/>.
+    /// </summary>
+    public ISemanticProvider<char, T>? SemanticProviderOnChar { get; internal init; }
+    /// <summary>
+    /// The built <see cref="Tokenizer{TChar}"/> on <see cref="char"/>.
+    /// </summary>
+    public Tokenizer<char>? TokenizerOnChar { get; internal init; }
+    /// <summary>
+    /// The built <see cref="CharParser{T}"/>.
+    /// </summary>
+    public CharParser<T>? CharParser { get; internal init; }
+}

--- a/src/FarkleNeo/Builder/GrammarBuilderExtensions.cs
+++ b/src/FarkleNeo/Builder/GrammarBuilderExtensions.cs
@@ -6,7 +6,9 @@ using System.Diagnostics;
 using Farkle.Builder.OperatorPrecedence;
 using Farkle.Diagnostics;
 using Farkle.Diagnostics.Builder;
+using Farkle.Grammars;
 using Farkle.Parser.Semantics;
+using Farkle.Parser.Tokenizers;
 
 namespace Farkle.Builder;
 
@@ -324,9 +326,120 @@ public static class GrammarBuilderExtensions
     }
 
     /// <summary>
-    /// Creates a <see cref="CharParser{T}"/> from the given <see cref="IGrammarBuilder{T}"/>.
+    /// Builds an <see cref="IGrammarBuilder"/>. This is the entry point to Farkle's builder.
     /// </summary>
     /// <typeparam name="T">The type of objects the parser will produce in case of success.</typeparam>
+    /// <param name="builder">The grammar to build.</param>
+    /// <param name="artifacts">The set of artifacts to build.</param>
+    /// <param name="options">Used to customize the building process. Optional.</param>
+    /// <param name="isSyntaxCheck">Whether to use a dummy semantic provider instead of building one.</param>
+    private static BuilderResult<T> BuildImpl<T>(this IGrammarBuilder builder, BuilderArtifacts artifacts,
+        BuilderOptions? options = null, bool isSyntaxCheck = false)
+    {
+        ArgumentNullExceptionCompat.ThrowIfNull(builder);
+
+        options ??= BuilderOptions.Default;
+
+        // Add dependencies between artifacts.
+        // The order is important; if an artifact appears in the first parameter,
+        // it cannot appear in the second parameter of a subsequent call.
+        AddArtifactDependencies(BuilderArtifacts.CharParser,
+            BuilderArtifacts.SemanticProviderOnChar | BuilderArtifacts.TokenizerOnChar | BuilderArtifacts.GrammarLrStateMachine);
+        AddArtifactDependencies(BuilderArtifacts.TokenizerOnChar,
+            BuilderArtifacts.GrammarDfaOnChar);
+        AddArtifactDependencies(BuilderArtifacts.GrammarLrStateMachine | BuilderArtifacts.GrammarDfaOnChar,
+            BuilderArtifacts.GrammarSummary);
+
+        Grammar? grammar = null;
+        ISemanticProvider<char, T>? semanticProvider = null;
+        Tokenizer<char>? tokenizer = null;
+        CharParser<T>? parser = null;
+
+        if (artifacts != BuilderArtifacts.None)
+        {
+            GrammarDefinition grammarDefinition = GrammarDefinition.Create(builder, options.Log, options.CancellationToken);
+
+            List<BuilderDiagnostic>? errors = null;
+            // We will collect errors only if we need to report them from a failing parser or tokenizer.
+            if ((artifacts & BuilderArtifacts.TokenizerOnChar | BuilderArtifacts.CharParser) != 0)
+            {
+                errors ??= [];
+            }
+
+            if ((artifacts & BuilderArtifacts.GrammarSummary) != 0)
+            {
+                grammar = GrammarBuild.Build(grammarDefinition, artifacts, options, errors);
+            }
+
+            object? customError = errors is null or [] ? null : new CompositeDiagnostic<BuilderDiagnostic>(errors);
+
+            if ((artifacts & BuilderArtifacts.TokenizerOnChar) != 0)
+            {
+                // Custom error is the same for both the parser and the tokenizer, which can
+                // give confusing messages when a failing tokenizer gets swapped with a
+                // working one. We can fix this by providing a separate custom error for the
+                // tokenizer.
+                tokenizer = Tokenizer.Create<char>(grammar!, false, customError);
+            }
+
+            if ((artifacts & BuilderArtifacts.SemanticProviderOnChar) != 0)
+            {
+                semanticProvider = isSyntaxCheck
+                    ? SyntaxChecker<char, T>.Instance!
+                    : SemanticProviderBuild.Build<T>(grammarDefinition);
+            }
+
+            if ((artifacts & BuilderArtifacts.CharParser) != 0)
+            {
+                parser = CharParser.Create(grammar!, tokenizer!, semanticProvider!, customError);
+            }
+        }
+
+        return new BuilderResult<T>
+        {
+            Grammar = grammar,
+            CharParser = parser,
+            SemanticProviderOnChar = semanticProvider,
+            TokenizerOnChar = tokenizer
+        };
+
+        // Adds dependencies between artifacts. If one of dependents is specified, dependencies will be built as well.
+        void AddArtifactDependencies(BuilderArtifacts dependents, BuilderArtifacts dependencies)
+        {
+            if ((artifacts & dependents) != 0)
+            {
+                artifacts |= dependencies;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds multiple artifacts from the given <see cref="IGrammarBuilder{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of objects the parser will produce in case of success.</typeparam>
+    /// <param name="builder">The grammar to build.</param>
+    /// <param name="artifacts">The set of artifacts to build.</param>
+    /// <param name="options">Used to customize the building process. Optional.</param>
+    /// <returns>
+    /// A <see cref="BuilderResult{T}"/> object with the properties of the requested artifacts populated.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The builder will reuse resources to build the requested artifacts where applicable.
+    /// </para>
+    /// <para>
+    /// Additional artifacts may be built beyond the ones requested, if they are dependencies of the requested
+    /// artifacts. For example, if <see cref="BuilderArtifacts.CharParser"/> is requested, the builder will also
+    /// build <see cref="BuilderArtifacts.TokenizerOnChar"/>, <see cref="BuilderArtifacts.SemanticProviderOnChar"/>.
+    /// </para>
+    /// </remarks>
+    public static BuilderResult<T> Build<T>(this IGrammarBuilder<T> builder, BuilderArtifacts artifacts, BuilderOptions? options = null) =>
+        builder.BuildImpl<T>(artifacts, options);
+
+    /// <summary>
+    /// Creates a <see cref="CharParser{T}"/> from the given <see cref="IGrammarBuilder{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The return type of the parser or semantic provider.</typeparam>
     /// <param name="builder">The grammar to build.</param>
     /// <param name="options">Used to customize the building process. Optional.</param>
     /// <returns>
@@ -336,18 +449,35 @@ public static class GrammarBuilderExtensions
     /// obtained by trying to parse any text, and casting the result's <see cref="ParserResult{T}.Error"/>
     /// property to <see cref="IReadOnlyList{BuilderDiagnostic}"/> of type <see cref="BuilderDiagnostic"/>.
     /// </returns>
-    public static CharParser<T> Build<T>(this IGrammarBuilder<T> builder, BuilderOptions? options = null)
-    {
-        ArgumentNullExceptionCompat.ThrowIfNull(builder);
+    public static CharParser<T> Build<T>(this IGrammarBuilder<T> builder, BuilderOptions? options = null) =>
+        builder.Build(BuilderArtifacts.CharParser, options).GetCharParserOrThrow();
 
-        options ??= BuilderOptions.Default;
-        GrammarDefinition grammarDefinition = GrammarDefinition.Create(builder, options.Log, options.CancellationToken);
-        List<BuilderDiagnostic> errors = [];
-        var grammar = GrammarBuild.Build(grammarDefinition, options, errors);
-        object? customError = errors is [] ? null : new CompositeDiagnostic<BuilderDiagnostic>(errors);
-        var semanticProvider = SemanticProviderBuild.Build<T>(grammarDefinition);
-        return CharParser.Create(grammar, semanticProvider, customError);
-    }
+    /// <summary>
+    /// Builds multiple artifacts from the given untyped <see cref="IGrammarBuilder"/>.
+    /// </summary>
+    /// <typeparam name="T">The supposed return type of the parser and the semantic provider. Must be a reference type.</typeparam>
+    /// <param name="builder">The grammar to build.</param>
+    /// <param name="artifacts">The set of artifacts to build.</param>
+    /// <param name="options">Used to customize the building process. Optional.</param>
+    /// <returns>
+    /// A <see cref="BuilderResult{T}"/> object with the properties of the requested artifacts populated.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The builder will reuse resources to build the requested artifacts where applicable.
+    /// </para>
+    /// <para>
+    /// Additional artifacts may be built beyond the ones requested, if they are dependencies of the requested
+    /// artifacts. For example, if <see cref="BuilderArtifacts.CharParser"/> is requested, the builder will also
+    /// build <see cref="BuilderArtifacts.TokenizerOnChar"/>, <see cref="BuilderArtifacts.SemanticProviderOnChar"/>.
+    /// </para>
+    /// <para>
+    /// If requested, the builder will create a syntax-checking parser and semantic provider that will not execute
+    /// any semantic actions and produce <see langword="null"/> semantic values on success.
+    /// </para>
+    /// </remarks>
+    public static BuilderResult<T?> BuildSyntaxCheck<T>(this IGrammarBuilder builder, BuilderArtifacts artifacts, BuilderOptions? options = null) where T : class? =>
+        builder.BuildImpl<T?>(artifacts, options, isSyntaxCheck: true);
 
     /// <summary>
     /// Creates a syntax-checking <see cref="CharParser{T}"/> from the given <see cref="IGrammarBuilder{T}"/>.
@@ -365,24 +495,19 @@ public static class GrammarBuilderExtensions
     /// obtained by trying to parse any text, and casting the result's <see cref="ParserResult{T}.Error"/>
     /// property to <see cref="IReadOnlyList{BuilderDiagnostic}"/> of type <see cref="BuilderDiagnostic"/>.
     /// </remarks>
-    public static CharParser<T?> BuildSyntaxCheck<T>(this IGrammarBuilder builder, BuilderOptions? options = null) where T : class?
-    {
-        ArgumentNullExceptionCompat.ThrowIfNull(builder);
+    public static CharParser<T?> BuildSyntaxCheck<T>(this IGrammarBuilder builder, BuilderOptions? options = null) where T : class? =>
+        builder.BuildSyntaxCheck<T>(BuilderArtifacts.CharParser, options).GetCharParserOrThrow();
 
-        options ??= BuilderOptions.Default;
-        GrammarDefinition grammarDefinition = GrammarDefinition.Create(builder, options.Log, options.CancellationToken);
-        List<BuilderDiagnostic> errors = [];
-        var grammar = GrammarBuild.Build(grammarDefinition, options, errors);
-        object? customError = errors is [] ? null : new CompositeDiagnostic<BuilderDiagnostic>(errors);
-        return CharParser.Create(grammar, SyntaxChecker<char, T>.Instance, customError);
-    }
-
-    /// <inheritdoc cref="BuildSyntaxCheck{T}"/>
+    /// <inheritdoc cref="BuildSyntaxCheck{T}(IGrammarBuilder, BuilderOptions?)"/>
     public static CharParser<object?> BuildSyntaxCheck(this IGrammarBuilder builder, BuilderOptions? options = null) =>
-        builder.BuildSyntaxCheck<object?>(options);
+        builder.BuildSyntaxCheck<object>(options);
+
+    /// <inheritdoc cref="BuildSyntaxCheck{T}(IGrammarBuilder, BuilderArtifacts, BuilderOptions?)"/>
+    public static BuilderResult<object?> BuildSyntaxCheck(this IGrammarBuilder builder, BuilderArtifacts artifacts, BuilderOptions? options = null) =>
+        builder.BuildSyntaxCheck<object>(artifacts, options);
 
     /// <summary>
-    /// Obsolete. Use <see cref="BuildSyntaxCheck"/> instead.
+    /// Obsolete. Use <see cref="BuildSyntaxCheck(IGrammarBuilder, BuilderOptions?)"/> instead.
     /// </summary>
     [Obsolete(Obsoletions.BuildUntypedMessage
 #if NET5_0_OR_GREATER

--- a/src/FarkleNeo/Builder/GrammarBuilderExtensions.cs
+++ b/src/FarkleNeo/Builder/GrammarBuilderExtensions.cs
@@ -363,7 +363,7 @@ public static class GrammarBuilderExtensions
             // We will collect errors only if we need to report them from a failing parser or tokenizer.
             if ((artifacts & BuilderArtifacts.TokenizerOnChar | BuilderArtifacts.CharParser) != 0)
             {
-                errors ??= [];
+                errors = [];
             }
 
             if ((artifacts & BuilderArtifacts.GrammarSummary) != 0)

--- a/src/FarkleNeo/CharParser.cs
+++ b/src/FarkleNeo/CharParser.cs
@@ -209,15 +209,19 @@ public static class CharParser
     /// <param name="semanticProvider">The <see cref="ISemanticProvider{TChar, T}"/> the parser will use.</param>
     /// <exception cref="ArgumentNullException"><paramref name="grammar"/> or <paramref name="semanticProvider"/>
     /// is <see langword="null"/>.</exception>
-    public static CharParser<T> Create<T>(Grammar grammar, ISemanticProvider<char, T> semanticProvider) =>
-        Create(grammar, semanticProvider, null);
+    public static CharParser<T> Create<T>(Grammar grammar, ISemanticProvider<char, T> semanticProvider)
+    {
+        Tokenizer<char> tokenizer = Tokenizer.Create<char>(grammar, throwIfError: false);
+        return Create(grammar, tokenizer, semanticProvider, null);
+    }
 
     /// <inheritdoc cref="Create{T}(Grammar, ISemanticProvider{char, T})"/>
+    /// <param name="tokenizer">The <see cref="Tokenizer{TChar}"/> the parser will use.</param>
     /// <param name="customError">A custom error object to be used instead of the default errors. This
     /// is typically provided by the builder, which has a more complete picture of what went wrong.</param>
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
     // See https://github.com/dotnet/roslyn/issues/40325
-    internal static CharParser<T> Create<T>(Grammar grammar, ISemanticProvider<char, T> semanticProvider, object? customError)
+    internal static CharParser<T> Create<T>(Grammar grammar, Tokenizer<char> tokenizer, ISemanticProvider<char, T> semanticProvider, object? customError)
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
     {
         ArgumentNullExceptionCompat.ThrowIfNull(grammar);
@@ -236,11 +240,6 @@ public static class CharParser
             return Fail(nameof(Resources.Parser_GrammarLrProblem));
         }
 
-        // TODO: Custom error is the same for both the parser and the tokenizer,
-        // which can give confusing messages when a failing tokenizer gets swapped
-        // with a working one. We can fix this by providing a separate custom error
-        // for the tokenizer.
-        Tokenizer<char> tokenizer = Tokenizer.Create<char>(grammar, throwIfError: false, customError);
         return new DefaultParser<T>(grammar, lrStateMachine, semanticProvider, tokenizer);
 
         CharParser<T> Fail(string resourceKey) =>

--- a/src/FarkleNeo/Parser/Semantics/SyntaxChecker.cs
+++ b/src/FarkleNeo/Parser/Semantics/SyntaxChecker.cs
@@ -5,7 +5,7 @@ using Farkle.Grammars;
 
 namespace Farkle.Parser.Semantics;
 
-internal sealed class SyntaxChecker<TChar, T> : ISemanticProvider<TChar, T?> where T : class?
+internal sealed class SyntaxChecker<TChar, T> : ISemanticProvider<TChar, T?>
 {
     private SyntaxChecker() { }
 

--- a/tests/Farkle.Tests.CSharp/BuilderArtifactsTests.cs
+++ b/tests/Farkle.Tests.CSharp/BuilderArtifactsTests.cs
@@ -1,0 +1,43 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+using Farkle.Builder;
+
+using static Farkle.Builder.BuilderArtifacts;
+
+namespace Farkle.Tests.CSharp;
+
+internal class BuilderArtifactsTests
+{
+    [TestCase(None, None)]
+    [TestCase(GrammarSummary, GrammarSummary)]
+    [TestCase(GrammarLrStateMachine, GrammarSummary)]
+    [TestCase(GrammarDfaOnChar, GrammarSummary)]
+    [TestCase(TokenizerOnChar, GrammarDfaOnChar | GrammarSummary)]
+    [TestCase(SemanticProviderOnChar, None)]
+    [TestCase(BuilderArtifacts.CharParser, SemanticProviderOnChar | TokenizerOnChar | GrammarDfaOnChar | GrammarLrStateMachine | GrammarSummary)]
+    public void TestBuildArtifacts(BuilderArtifacts requestedArtifacts, BuilderArtifacts builtArtifacts)
+    {
+        var result = Terminals.Int32("Number").Build(requestedArtifacts);
+
+        // It is obvious that the requested artifacts will get built;
+        // this way we don't have to specify them twice in the test cases.
+        builtArtifacts |= requestedArtifacts;
+
+        Assert.Multiple(() =>
+        {
+            AssertNullIf(result.Grammar, GrammarSummary);
+            AssertNullIf(result?.Grammar?.LrStateMachine, GrammarLrStateMachine);
+            AssertNullIf(result?.Grammar?.DfaOnChar, GrammarDfaOnChar);
+            AssertNullIf(result?.TokenizerOnChar, TokenizerOnChar);
+            AssertNullIf(result?.SemanticProviderOnChar, SemanticProviderOnChar);
+            AssertNullIf(result?.CharParser, BuilderArtifacts.CharParser);
+        });
+
+        void AssertNullIf(object? obj, BuilderArtifacts artifact)
+        {
+            bool hasArtifact = (builtArtifacts & artifact) != 0;
+            Assert.That(obj, hasArtifact ? Is.Not.Null : Is.Null);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds low-level builder APIs that will replace the `DesigntimeFarkleBuild` module of Farkle 6. New overloads of `GrammarBuilderExtensions.Build(SyntaxCheck)` were introduced that accept a `BuilderArtifacts` enum, which specifies what to build from an `IGrammarBuilder`. This can be a regular `CharParser<T>`, but can also be just a tokenizer, a semantic provider (which avoids building the grammar), or a `Grammar` (and newly to Farkle 7, a `Grammar` with only certain state machines or none at all).

The builder was updated to skip computing unnecessary information, and the `Build` extension methods were refactored to eliminate duplication, with the builder's entry point being consolidated to the newly introduced `GrammarBuilderExtensions.BuildImpl` internal method.