### PR TITLE
Improve DFA conflict resolution on noise symbols.

### DIFF
--- a/src/FarkleNeo/Builder/Dfa/DfaBuild.cs
+++ b/src/FarkleNeo/Builder/Dfa/DfaBuild.cs
@@ -121,11 +121,21 @@ internal readonly struct DfaBuild<TChar> where TChar : unmanaged, IComparable<TC
 
         for (int i = 1; i < acceptSymbols.Count; i++)
         {
-            if (firstSymbol != acceptSymbols[i].SymbolIndex)
+            var (priority, symbol) = acceptSymbols[i];
+            if (firstSymbol != symbol)
             {
-                if (prioritizeSymbols && firstPriority > acceptSymbols[i].Priority)
+                if (prioritizeSymbols)
                 {
-                    return firstSymbol;
+                    if (firstPriority > priority)
+                    {
+                        return firstSymbol;
+                    }
+                    // Conflicts between noise symbols do not cause an error because
+                    // it doesn't matter which one gets chosen.
+                    if (firstPriority == priority && priority == NoisePriority)
+                    {
+                        continue;
+                    }
                 }
                 return null;
             }

--- a/src/FarkleNeo/Builder/Dfa/DfaBuild.cs
+++ b/src/FarkleNeo/Builder/Dfa/DfaBuild.cs
@@ -42,6 +42,11 @@ internal readonly struct DfaBuild<TChar> where TChar : unmanaged, IComparable<TC
     /// </summary>
     private const int TerminalPriority = 1;
 
+    /// <summary>
+    /// The priority number for regexes of noise symbols.
+    /// </summary>
+    private const int NoisePriority = 2;
+
     private static bool IsRegexChars(Regex regex, out ImmutableArray<(TChar, TChar)> ranges, out bool isInverted)
     {
         if (typeof(TChar) == typeof(char))
@@ -498,6 +503,10 @@ internal readonly struct DfaBuild<TChar> where TChar : unmanaged, IComparable<TC
             // which would make it unable to flow from the root to the end leaf.
             bool isVoid = true;
             int? endLeafIndexTerminal = null, endLeafIndexLiteral = null;
+            if (Symbols.GetName(i).Kind == TokenSymbolKind.Noise)
+            {
+                endLeafIndexTerminal = endLeafIndexLiteral = AddLeaf(new RegexLeaf.End(i, NoisePriority));
+            }
             foreach (var r in regexes)
             {
                 var info = Visit(in this, i, r, caseSensitive);

--- a/src/FarkleNeo/Builder/Dfa/DfaBuild.cs
+++ b/src/FarkleNeo/Builder/Dfa/DfaBuild.cs
@@ -28,24 +28,24 @@ internal readonly struct DfaBuild<TChar> where TChar : unmanaged, IComparable<TC
 
     private readonly BuilderLogger Log;
 
-    // Priorities. The lower the number, the higher the priority.
+    // Priorities. The higher the number, the higher the priority.
 
     /// <summary>
-    /// The priority number for fixed-size regexes that do
-    /// not directly or indirectly contain a star operator.
+    /// The priority number for regexes of noise symbols.
     /// </summary>
-    private const int LiteralPriority = 0;
+    private const int NoisePriority = int.MinValue;
 
     /// <summary>
     /// The priority number for regexes that do not fall into
     /// any other category.
     /// </summary>
-    private const int TerminalPriority = 1;
+    private const int TerminalPriority = 0;
 
     /// <summary>
-    /// The priority number for regexes of noise symbols.
+    /// The priority number for fixed-size regexes that do
+    /// not directly or indirectly contain a star operator.
     /// </summary>
-    private const int NoisePriority = 2;
+    private const int LiteralPriority = 1;
 
     private static bool IsRegexChars(Regex regex, out ImmutableArray<(TChar, TChar)> ranges, out bool isInverted)
     {
@@ -87,13 +87,13 @@ internal readonly struct DfaBuild<TChar> where TChar : unmanaged, IComparable<TC
     /// </summary>
     /// <param name="symbols">The symbols of the grammar.</param>
     /// <param name="caseSensitive">Whether the DFA will match characters case-sensitively.</param>
-    /// <param name="prioritizeFixedLengthSymbols">Whether symbols with fixed-length regexes
-    /// will be prioritized in cases of conflicts.</param>
+    /// <param name="prioritizeSymbols">Whether to try to resolve conflicts by assigning a priority
+    /// to symbols based on their prioerties.</param>
     /// <param name="maxTokenizerStates">The value of <see cref="BuilderOptions.MaxTokenizerStates"/>.</param>
     /// <param name="log">Used to log events in the building process.</param>
     /// <param name="cancellationToken">Used to cancel the building process.</param>
     public static DfaWriter<TChar>? Build(IGrammarSymbolsProvider symbols, bool caseSensitive = false,
-        bool prioritizeFixedLengthSymbols = true, int maxTokenizerStates = -1, BuilderLogger log = default,
+        bool prioritizeSymbols = true, int maxTokenizerStates = -1, BuilderLogger log = default,
         CancellationToken cancellationToken = default)
     {
         var @this = new DfaBuild<TChar>(symbols, log, cancellationToken);
@@ -104,10 +104,10 @@ internal readonly struct DfaBuild<TChar> where TChar : unmanaged, IComparable<TC
         {
             return null;
         }
-        return @this.WriteDfa(dfaStates, prioritizeFixedLengthSymbols);
+        return @this.WriteDfa(dfaStates, prioritizeSymbols);
     }
 
-    private static int? FindDominantSymbol(List<(int Priority, int SymbolIndex)> acceptSymbols, bool prioritizeFixedLengthSymbols)
+    private static int? FindDominantSymbol(List<(int Priority, int SymbolIndex)> acceptSymbols, bool prioritizeSymbols)
     {
         switch (acceptSymbols)
         {
@@ -115,7 +115,7 @@ internal readonly struct DfaBuild<TChar> where TChar : unmanaged, IComparable<TC
             case [(_, var symbol)]: return symbol;
         }
 
-        acceptSymbols.Sort((x1, x2) => x1.Priority.CompareTo(x2.Priority));
+        acceptSymbols.Sort((x1, x2) => -x1.Priority.CompareTo(x2.Priority));
 
         var (firstPriority, firstSymbol) = acceptSymbols[0];
 
@@ -123,7 +123,7 @@ internal readonly struct DfaBuild<TChar> where TChar : unmanaged, IComparable<TC
         {
             if (firstSymbol != acceptSymbols[i].SymbolIndex)
             {
-                if (prioritizeFixedLengthSymbols && firstPriority < acceptSymbols[i].Priority)
+                if (prioritizeSymbols && firstPriority > acceptSymbols[i].Priority)
                 {
                     return firstSymbol;
                 }
@@ -135,7 +135,7 @@ internal readonly struct DfaBuild<TChar> where TChar : unmanaged, IComparable<TC
         return firstSymbol;
     }
 
-    private DfaWriter<TChar> WriteDfa(List<DfaState> states, bool prioritizeFixedLengthSymbols)
+    private DfaWriter<TChar> WriteDfa(List<DfaState> states, bool prioritizeSymbols)
     {
         DfaWriter<TChar> dfaWriter = new(states.Count);
         HashSet<BitSet>? seenConflicts = null;
@@ -164,7 +164,7 @@ internal readonly struct DfaBuild<TChar> where TChar : unmanaged, IComparable<TC
                 dfaWriter.SetDefaultTransition(dt);
             }
 
-            if (FindDominantSymbol(state.AcceptSymbols, prioritizeFixedLengthSymbols) is { } sym)
+            if (FindDominantSymbol(state.AcceptSymbols, prioritizeSymbols) is { } sym)
             {
                 dfaWriter.AddAccept(Symbols.GetTokenSymbolHandle(sym));
             }

--- a/tests/Farkle.Tests/Common.fs
+++ b/tests/Farkle.Tests/Common.fs
@@ -27,8 +27,8 @@ let private terminalIndexSemanticProvider = {new ISemanticProvider<char, int> wi
 /// Until the LALR builder gets implemented, this function manually
 /// constructs the LR state machine.
 /// This is an advanced overload that also allows you to prioritize
-/// fixed-length symbols.
-let buildSimpleRegexMatcherEx caseSensitive prioritizeFixedLengthSymbols regexes =
+/// symbols.
+let buildSimpleRegexMatcherEx caseSensitive prioritizeSymbols regexes =
     let gw = GrammarWriter()
     let regexes = Array.ofList regexes
     let count = Array.length regexes
@@ -52,7 +52,7 @@ let buildSimpleRegexMatcherEx caseSensitive prioritizeFixedLengthSymbols regexes
         member _.GetRegex i = regexes[i]
         member _.GetTokenSymbolHandle i = tokenSymbols[i]
         member _.GetName i = BuilderSymbolName($"Token{i}", TokenSymbolKind.Terminal, false)}
-    DfaBuild<char>.Build(symbolsProvider, caseSensitive, prioritizeFixedLengthSymbols, Int32.MaxValue)
+    DfaBuild<char>.Build(symbolsProvider, caseSensitive, prioritizeSymbols, Int32.MaxValue)
     |> ValueOption.ofObj
     |> ValueOption.iter gw.AddStateMachine
     gw.SetGrammarInfo(gw.GetOrAddString("SimpleGrammar"), rootNonterminal, GrammarAttributes.None)

--- a/tests/Farkle.Tests/RegexTests.fs
+++ b/tests/Farkle.Tests/RegexTests.fs
@@ -127,6 +127,16 @@ let tests = testList "Regex tests" [
         Expect.equal dfa.[0].DefaultTransition -1 "The unreachable Anything Else edge was not removed"
     }
 
+    test "DFA conflicts between terminals and noise symbols are resolved in favor of the former" {
+        let parser =
+            Regex.regexString ".+"
+            |> terminalU "MyTerminal"
+            |> _.AddNoiseSymbol("Noise", Regex.string "aaa")
+            |> _.BuildSyntaxCheck()
+        Expect.isFalse parser.IsFailing "Building the grammar failed"
+        expectIsParseSuccess (CharParser.parseString parser "aaa") "The terminal was not recognized"
+    }
+
 #if false // TODO-FARKLE7: Reevaluate when the builder is implemented in Farkle 7.
     test "DFA conflict messages come with a correct example word" {
         let impl regex1 regex2 exampleWord =

--- a/tests/Farkle.Tests/RegexTests.fs
+++ b/tests/Farkle.Tests/RegexTests.fs
@@ -137,6 +137,16 @@ let tests = testList "Regex tests" [
         expectIsParseSuccess (CharParser.parseString parser "aaa") "The terminal was not recognized"
     }
 
+    test "DFA conflicts between noise symbols do not cause a build error" {
+        let parser =
+            Regex.string "x"
+            |> terminalU "MyTerminal"
+            |> _.AddNoiseSymbol("Noise1", Regex.regexString "a|b|c")
+            |> _.AddNoiseSymbol("Noise2", Regex.regexString "a|d|e")
+            |> _.BuildSyntaxCheck()
+        Expect.isFalse parser.IsFailing "Building the grammar failed"
+    }
+
 #if false // TODO-FARKLE7: Reevaluate when the builder is implemented in Farkle 7.
     test "DFA conflict messages come with a correct example word" {
         let impl regex1 regex2 exampleWord =


### PR DESCRIPTION
Fixes #264.

* A conflict between a terminal and a noise symbol will be resolved in favor of the former.
* A conflict between multiple noise symbols will be resolved in favor of an unspecified one, without causing an error.
  The reason for this is that these symbols are known to be treated the same by the parser, and therefore the choice of symbol would be insignificant.