### PR TITLE
Clean-up framework compatibility code.

### DIFF
--- a/src/FarkleNeo/Buffers/PooledSegmentBufferWriter.cs
+++ b/src/FarkleNeo/Buffers/PooledSegmentBufferWriter.cs
@@ -234,7 +234,7 @@ internal sealed class PooledSegmentBufferWriter<T> : IBufferWriter<T>, IDisposab
                 return;
             }
 
-#if !NETSTANDARD2_0
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
 #endif
             {

--- a/src/FarkleNeo/Compatibility/ArgumentOutOfRangeExceptionCompat.cs
+++ b/src/FarkleNeo/Compatibility/ArgumentOutOfRangeExceptionCompat.cs
@@ -1,13 +1,15 @@
 // Copyright © Theodore Tsirpanis and Contributors.
 // SPDX-License-Identifier: MIT
 
+#if NET8_0_OR_GREATER
+global using ArgumentOutOfRangeExceptionCompat = System.ArgumentOutOfRangeException;
+#else
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Farkle.Compatibility;
 
-// TODO: Redirect to ArgumentOutOfRangeException once we target .NET 8.
 internal static class ArgumentOutOfRangeExceptionCompat
 {
     [DoesNotReturn, StackTraceHidden]
@@ -21,3 +23,4 @@ internal static class ArgumentOutOfRangeExceptionCompat
             ThrowNegative(value, paramName);
     }
 }
+#endif

--- a/src/FarkleNeo/Compatibility/BitOperationsCompat.cs
+++ b/src/FarkleNeo/Compatibility/BitOperationsCompat.cs
@@ -4,7 +4,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NETCOREAPP
+#if NETCOREAPP3_0_OR_GREATER
 global using BitOperationsCompat = System.Numerics.BitOperations;
 #else
 using System.Runtime.CompilerServices;

--- a/src/FarkleNeo/Compatibility/EncoderCompat.cs
+++ b/src/FarkleNeo/Compatibility/EncoderCompat.cs
@@ -1,7 +1,7 @@
 // Copyright © Theodore Tsirpanis and Contributors.
 // SPDX-License-Identifier: MIT
 
-#if !(NETSTANDARD2_1_OR_GREATER || NET)
+#if !(NETCOREAPP || NETSTANDARD2_1_OR_GREATER)
 using System.Runtime.InteropServices;
 
 namespace System.Text;

--- a/src/FarkleNeo/Compatibility/EncodingCompat.cs
+++ b/src/FarkleNeo/Compatibility/EncodingCompat.cs
@@ -1,7 +1,7 @@
 // Copyright © Theodore Tsirpanis and Contributors.
 // SPDX-License-Identifier: MIT
 
-#if !(NETSTANDARD2_1_OR_GREATER || NET)
+#if !(NETCOREAPP || NETSTANDARD2_1_OR_GREATER)
 using System.Runtime.InteropServices;
 
 namespace System.Text;

--- a/src/FarkleNeo/Compatibility/EncodingExtensionsCompat.cs
+++ b/src/FarkleNeo/Compatibility/EncodingExtensionsCompat.cs
@@ -4,7 +4,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if !NET
+#if !NET5_0_OR_GREATER
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 

--- a/src/FarkleNeo/Compatibility/SpanAction.cs
+++ b/src/FarkleNeo/Compatibility/SpanAction.cs
@@ -1,7 +1,7 @@
 // Copyright © Theodore Tsirpanis and Contributors.
 // SPDX-License-Identifier: MIT
 
-#if NETSTANDARD2_0
+#if !(NETCOREAPP || NETSTANDARD2_1_OR_GREATER)
 namespace System;
 
 internal delegate void SpanAction<T, TArg>(Span<T> span, TArg arg);

--- a/src/FarkleNeo/FarkleNeo.csproj
+++ b/src/FarkleNeo/FarkleNeo.csproj
@@ -21,9 +21,9 @@
     <PackageReference Include="PolySharp" PrivateAssets="all" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="BitCollections" />
-    <Using Include="Farkle.Compatibility" />
+    <Using Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net8.0'))" Include="Farkle.Compatibility"/>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'netstandard2.1'))">
     <PackageReference Include="Microsoft.Bcl.HashCode" />
     <PackageReference Include="System.Buffers" />
     <PackageReference Include="System.Memory" />


### PR DESCRIPTION
Conditional compilation directives were standardized to consistently define modern frameworks as `NETCOREAPP || NETSTANDARD2_1_OR_GREATER`, and some specific versions were added.
Also we make use of the `IsTargetFrameworkCompatible` property function in the project file.