### PR TITLE
Fix conflict detection in the LR state machine writer.

### DIFF
--- a/src/FarkleNeo/Grammars/Writers/LrWriter.cs
+++ b/src/FarkleNeo/Grammars/Writers/LrWriter.cs
@@ -163,6 +163,7 @@ internal sealed class LrWriter
                     {
                         return true;
                     }
+                    previousKey = key;
                 }
             }
             return false;

--- a/tests/Farkle.Tests/RegressionTests.fs
+++ b/tests/Farkle.Tests/RegressionTests.fs
@@ -7,9 +7,12 @@ module Farkle.Tests.RegressionTests
 
 open Expecto
 open Farkle
+open Farkle.Builder
 open Farkle.Diagnostics
 
 let private reproduceIssue issueNumber = test (sprintf "GitHub issue #%02i" issueNumber)
+
+let private freproduceIssue issueNumber = ftest (sprintf "GitHub issue #%02i" issueNumber)
 
 [<Tests>]
 let tests = testList "Regression tests" [
@@ -23,5 +26,29 @@ let tests = testList "Regression tests" [
         match result with
         | ParserError(ParserDiagnostic(TextPosition(1, 1), LexicalError _)) -> ()
         | _ -> failtestNoStackf $"The issue was not reproduced: {result}"
+    }
+
+    reproduceIssue 279 {
+        let grammar =
+            let term1 = virtualTerminal "T1"
+            let term2 = virtualTerminal "T2"
+
+            let nont1 = nonterminalU "N1"
+            let nont2 = nonterminalU "N2"
+
+            nont1.SetProductions(
+                !% term1,
+                !% term2 .>> nont2 .>> term2
+            )
+            nont2.SetProductions(
+                !% nont1 .>> nont2,
+                !% nont1,
+                empty
+            )
+            nont1
+            |> GrammarBuilder.buildSyntaxCheck
+            |> _.GetGrammar()
+
+        Expect.isTrue grammar.LrStateMachine.HasConflicts "The grammar should have conflicts"
     }
 ]


### PR DESCRIPTION
Fixes #279. A regression test was added.

The same oversight was not found in other `previous*`-named variables.