### PR TITLE
Update the tokenizer composability model.

### DIFF
--- a/src/FarkleNeo/Parser/ParserState.cs
+++ b/src/FarkleNeo/Parser/ParserState.cs
@@ -63,6 +63,8 @@ public struct ParserState
     /// <seealso cref="ParserExtensions.ParseFileAsync"/>
     public string? InputName { get; set; }
 
+    internal ParserStateAttributes Attributes { get; set; }
+
     /// <summary>
     /// Whether suspending the tokenizer will have any effect.
     /// </summary>
@@ -72,7 +74,12 @@ public struct ParserState
     /// the tokenizer, and when the tokenizer returns and wants to suspend again, it will
     /// throw with a message that it is already suspended.
     /// </remarks>
-    internal bool TokenizerSupportsSuspending { get; set; }
+    internal readonly bool TokenizerSupportsSuspending =>
+        (Attributes & ParserStateAttributes.TokenizerSupportsSuspending) != 0;
+
+    /// <inheritdoc cref="Tokenizers.TokenizerExtensions.IsSingleTokenizerInChain"/>
+    internal readonly bool IsSingleTokenizerInChain =>
+        (Attributes & ParserStateAttributes.HasMoreThanOneTokenizerInChain) == 0;
 
     internal void Consume<T>(ReadOnlySpan<T> characters)
     {

--- a/src/FarkleNeo/Parser/ParserStateAttributes.cs
+++ b/src/FarkleNeo/Parser/ParserStateAttributes.cs
@@ -1,0 +1,27 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+namespace Farkle.Parser;
+
+/// <summary>
+/// Internal characteristics of a parsing operation.
+/// </summary>
+/// <seealso cref="ParserState.Attributes"/>
+[Flags]
+internal enum ParserStateAttributes : byte
+{
+    /// <summary>
+    /// No attributes are defined.
+    /// </summary>
+    None = 0,
+    /// <inheritdoc cref="ParserState.TokenizerSupportsSuspending"/>
+    TokenizerSupportsSuspending = 1,
+    /// <summary>
+    /// The inverse of <see cref="ParserState.IsSingleTokenizerInChain"/>.
+    /// </summary>
+    /// <remarks>
+    /// The default state is that there is only one tokenizer in the chain, which is why
+    /// this attribute is the inverse of the public API.
+    /// </remarks>
+    HasMoreThanOneTokenizerInChain = 2
+}

--- a/src/FarkleNeo/Parser/Tokenizers/ChainedTokenizer.cs
+++ b/src/FarkleNeo/Parser/Tokenizers/ChainedTokenizer.cs
@@ -42,7 +42,9 @@ internal sealed class ChainedTokenizer<TChar> : Tokenizer<TChar>
         // We mark this parser operation as supporting suspending the tokenizer.
         // It might cause some issues if the tokenizer changes in the middle of the
         // operation but this is not a supported scenario.
-        input.State.TokenizerSupportsSuspending = true;
+        input.State.Attributes =
+            ParserStateAttributes.TokenizerSupportsSuspending
+            | (Components.Length >= 1 ? ParserStateAttributes.HasMoreThanOneTokenizerInChain : 0);
         // Get the state of the chained tokenizer. If we have not suspended before,
         // it will be null.
         var tokenizerState = input.GetChainedTokenizerStateOrNull();

--- a/src/FarkleNeo/Parser/Tokenizers/Tokenizer.cs
+++ b/src/FarkleNeo/Parser/Tokenizers/Tokenizer.cs
@@ -37,7 +37,8 @@ public abstract class Tokenizer<TChar>
     /// <para>
     /// Additionally, tokenizers that set this property to <see langword="true"/> must
     /// handle thrown exceptions of type <sep cref="ParserApplicationException"/> and
-    /// translate them to error <see cref="TokenizerResult"/>s.
+    /// translate them to error <see cref="TokenizerResult"/>s, and must check the
+    /// <see cref="ParserInputReader{TChar}.IsFinalBlock"/> property.
     /// </para>
     /// </remarks>
     internal bool CanSkipChainedTokenizerWrapping { get; private protected init; }
@@ -60,10 +61,19 @@ public abstract class Tokenizer<TChar>
     /// In this case the result will be written to <paramref name="result"/>.
     /// </para>
     /// <para>
-    /// <see langword="false"/> if either the tokenizer needs more input to make a decision
-    /// or input has ended if the <see cref="ParserInputReader{TChar}.IsFinalBlock"/> property
-    /// of <paramref name="input"/> is <see langword="true"/>. In this case the tokenizer
-    /// should be invoked again after more input has been provided.
+    /// <see langword="false"/> in one of the following cases:
+    /// <list type="bullet">
+    /// <item><description>The tokenizer needs more input to make a decision.</description></item>
+    /// <item><description>Input has ended and the <see cref="ParserInputReader{TChar}.IsFinalBlock"/>
+    /// property of <paramref name="input"/> is <see langword="true"/>.</description></item>
+    /// <item><description><strong>Not applicable for tokenizers that are wrapped in a chain:</strong>
+    /// The tokenizer has encountered a noise symbol.</description></item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// A tokenizer object is considered to be wrapped in a chain if it was returned by
+    /// <see cref="ChainedTokenizerBuilder{TChar}.Build"/> method, or by any other public
+    /// API of Farkle.
     /// </para>
     /// </returns>
     public abstract bool TryGetNextToken(ref ParserInputReader<TChar> input, ITokenSemanticProvider<TChar> semanticProvider, out TokenizerResult result);

--- a/src/FarkleNeo/Parser/Tokenizers/TokenizerExtensions.cs
+++ b/src/FarkleNeo/Parser/Tokenizers/TokenizerExtensions.cs
@@ -47,6 +47,19 @@ public static class TokenizerExtensions
     }
 
     /// <summary>
+    /// Returns whether the tokenizer chain in a parsing operation consists of only one tokenizer.
+    /// </summary>
+    /// <typeparam name="TChar">The type of characters the tokenizer processes.</typeparam>
+    /// <param name="input">The state of the parsing operation.</param>
+    /// <remarks>
+    /// If this property is <see langword="true"/>, tokenizers can avoid exiting when they
+    /// encounter a noise symbol, and instead continue tokenizing. Checking for this property
+    /// is optional and provides a performance improvement.
+    /// </remarks>
+    public static bool IsSingleTokenizerInChain<TChar>(this in ParserInputReader<TChar> input) =>
+        input.State.IsSingleTokenizerInChain;
+
+    /// <summary>
     /// Suspends the tokenization process and sets it to resume at the specified <see cref="Tokenizer{TChar}"/>.
     /// </summary>
     /// <typeparam name="TChar">The type of characters the tokenizer processes.</typeparam>


### PR DESCRIPTION
While porting the samples to FarkleNeo, it was discovered that the existing tokenizer extensibility model was not adequate to implement the indent-based grammar. This PR makes the following changes:

* Instead of going through the chain once, the chained tokenizer keeps running all components until:
  * One of them returns `true`.
  * One of them suspends.
  * No input characters were consumed after all components had the opportunity to run and returned false.
* Tokenizer _implementations_ are no longer greedy. When they encounter a noise symbol they must consume its characters and return `false` instead of continuing until they encounter a terminal.
  * Tokenizers can forgo yielding if they are the only ones in the chain, and an extension method on `ParserInputReader<TChar>` was added to check for it.
    * Checking for this property is mandatory for tokenizers that can skip the chained tokenizer wrapping.
  * The chained tokenizer wrapping maintains its eager semantics, which means that from the perspective of the parser, if a tokenizer returns `false`, the parser must still exit and return with more available input.

The new design was validated locally by successfully running the indent-based grammar checks.