### PR TITLE
Update to .NET 9 SDK and C# 13.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Set up .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
+          dotnet-quality: preview
       - name: Restore .NET local tools
         run: dotnet tool restore
       - name: Run benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Set up .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
+          dotnet-quality: preview
       - name: Restore .NET local tools
         run: dotnet tool restore
       - name: Enable SonarCloud scanning

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Set up .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
+          dotnet-quality: preview
       - name: Restore .NET local tools
         run: dotnet tool restore
       - name: Build documentation

--- a/eng/build.fs
+++ b/eng/build.fs
@@ -223,7 +223,7 @@ let runMSBuildTestsNetFramework _ =
     DotNet.build id farkleToolsProject
 
     let testProjectDirectory = Path.getDirectory msBuildTestProject
-    let customWorkerPath = Path.getFullName "./src/Farkle.Tools/bin/Release/net6.0/Farkle.Tools.dll"
+    let customWorkerPath = Path.getFullName "./src/Farkle.Tools/bin/Release/net8.0/Farkle.Tools.dll"
     // dotnet clean sometimes fails; this is faster and cleans only this project.
     cleanBinObj testProjectDirectory
     msBuildTestProject

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
     "sdk": {
-        "version": "8.0.100",
-        "rollForward": "latestFeature"
+        "version": "9.0.100-rc.1.24452.12",
+        "rollForward": "latestFeature",
+        "allowPrerelease": true
     }
 }

--- a/performance/Farkle6.Samples/Farkle6.Samples.fsproj
+++ b/performance/Farkle6.Samples/Farkle6.Samples.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GOLDMetaLanguage.fs" />

--- a/sample/Farkle.Samples.CSharp/Farkle.Samples.CSharp.csproj
+++ b/sample/Farkle.Samples.CSharp/Farkle.Samples.CSharp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>
   </PropertyGroup>

--- a/sample/Farkle.Samples.CSharp/Farkle.Samples.CSharp.csproj
+++ b/sample/Farkle.Samples.CSharp/Farkle.Samples.CSharp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>12</LangVersion>
+    <LangVersion>13</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\FarkleNeo\FarkleNeo.csproj" />

--- a/sample/Farkle.Samples.CSharp/SimpleMaths.cs
+++ b/sample/Farkle.Samples.CSharp/SimpleMaths.cs
@@ -29,13 +29,11 @@ namespace Farkle.Samples.CSharp
                 expression.Extended().Append("^").Extend(expression).Finish(Math.Pow),
                 "(".Appended().Extend(expression).Append(")").AsProduction());
 
-            var opScope = new OperatorScope(
+            Builder = expression.WithOperatorScope(
                 new LeftAssociative("+", "-"),
                 new LeftAssociative("*", "/"),
                 new PrecedenceOnly(NEG),
                 new RightAssociative("^"));
-
-            Builder = expression.WithOperatorScope(opScope);
             Parser = Builder.Build();
         }
     }

--- a/sample/Farkle.Samples.FSharp/Farkle.Samples.FSharp.fsproj
+++ b/sample/Farkle.Samples.FSharp/Farkle.Samples.FSharp.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../../src/FarkleNeo/Farkle.fs"/>

--- a/src/Farkle.Tools.MSBuild/Farkle.Tools.MSBuild.fsproj
+++ b/src/Farkle.Tools.MSBuild/Farkle.Tools.MSBuild.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../NuGet.props" />
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <Description>Farkle's integration with MSBuild. Using this package on a project will precompile its grammars ahead of time when it is built.
 
 Building projects that use the precompiler with Visual Studio for Windows or with the .NET Framework-based "msbuild" command also requires a matching version of https://nuget.org/packages/Farkle.Tools to be installed. Learn more in https://teo-tsirpanis.github.io/Farkle/the-precompiler.html#Building-from-an-IDE</Description>

--- a/src/Farkle.Tools.MSBuild/build/Farkle.Tools.MSBuild.props
+++ b/src/Farkle.Tools.MSBuild/build/Farkle.Tools.MSBuild.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="$(MSBuildRuntimeType) == Core">
-    <FarkleTaskAssembly>$(MSBuildThisFileDirectory)../tools/net6.0/Farkle.Tools.MSBuild.dll</FarkleTaskAssembly>
+    <FarkleTaskAssembly>$(MSBuildThisFileDirectory)../tools/net8.0/Farkle.Tools.MSBuild.dll</FarkleTaskAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="$(MSBuildRuntimeType) != Core">
     <FarkleTaskAssembly>$(MSBuildThisFileDirectory)../tools/netstandard2.0/Farkle.Tools.MSBuild.dll</FarkleTaskAssembly>

--- a/src/Farkle.Tools.Precompiler/Farkle.Tools.Precompiler.fsproj
+++ b/src/Farkle.Tools.Precompiler/Farkle.Tools.Precompiler.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PrecompilerCommon.fs" />

--- a/src/Farkle.Tools/Farkle.Tools.fsproj
+++ b/src/Farkle.Tools/Farkle.Tools.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../NuGet.props" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <RollForward>LatestMajor</RollForward>

--- a/src/FarkleNeo/Builder/BuilderResult.cs
+++ b/src/FarkleNeo/Builder/BuilderResult.cs
@@ -12,7 +12,7 @@ namespace Farkle.Builder;
 /// </summary>
 /// <typeparam name="T">The type of objects the parser will produce in case of success.</typeparam>
 /// <remarks>
-/// All properties of this class are nullable and they are populated based on the <see cref="BuilderArtifacts"/>
+/// All properties of this class are nullable and populated based on the <see cref="BuilderArtifacts"/>
 /// that were requested when building.
 /// </remarks>
 /// <seealso cref="GrammarBuilderExtensions.Build{T}(IGrammarBuilder{T}, BuilderArtifacts, BuilderOptions?)"/>
@@ -29,14 +29,17 @@ public sealed class BuilderResult<T>
     /// The built <see cref="Grammar"/>.
     /// </summary>
     public Grammar? Grammar { get; internal init; }
+
     /// <summary>
     /// The built <see cref="ISemanticProvider{TChar, T}"/> on <see cref="char"/>.
     /// </summary>
     public ISemanticProvider<char, T>? SemanticProviderOnChar { get; internal init; }
+
     /// <summary>
     /// The built <see cref="Tokenizer{TChar}"/> on <see cref="char"/>.
     /// </summary>
     public Tokenizer<char>? TokenizerOnChar { get; internal init; }
+
     /// <summary>
     /// The built <see cref="CharParser{T}"/>.
     /// </summary>

--- a/src/FarkleNeo/Builder/GrammarBuild.cs
+++ b/src/FarkleNeo/Builder/GrammarBuild.cs
@@ -16,11 +16,11 @@ namespace Farkle.Builder;
 /// </summary>
 internal static class GrammarBuild
 {
-    private static readonly Regex NewLineRegex = Regex.Choice([Regex.OneOf(['\n', '\r']), Regex.Literal("\r\n")]);
+    private static readonly Regex NewLineRegex = Regex.Choice(Regex.OneOf('\n', '\r'), Regex.Literal("\r\n"));
 
-    private static readonly Regex WhitespaceRegex = Regex.OneOf(['\t', '\n', '\r', ' ']).AtLeast(1);
+    private static readonly Regex WhitespaceRegex = Regex.OneOf('\t', '\n', '\r', ' ').AtLeast(1);
 
-    private static readonly Regex WhitespaceNoNewLineRegex = Regex.OneOf(['\t', ' ']).AtLeast(1);
+    private static readonly Regex WhitespaceNoNewLineRegex = Regex.OneOf('\t', ' ').AtLeast(1);
 
     private static TokenSymbolAttributes GetTerminalFlags(ISymbolBase symbol, out bool hasSpecialName)
     {

--- a/src/FarkleNeo/Builder/GrammarBuilderExtensions.cs
+++ b/src/FarkleNeo/Builder/GrammarBuilderExtensions.cs
@@ -361,7 +361,7 @@ public static class GrammarBuilderExtensions
 
             List<BuilderDiagnostic>? errors = null;
             // We will collect errors only if we need to report them from a failing parser or tokenizer.
-            if ((artifacts & BuilderArtifacts.TokenizerOnChar | BuilderArtifacts.CharParser) != 0)
+            if ((artifacts & (BuilderArtifacts.TokenizerOnChar | BuilderArtifacts.CharParser)) != 0)
             {
                 errors = [];
             }

--- a/src/FarkleNeo/Builder/GrammarBuilderExtensions.cs
+++ b/src/FarkleNeo/Builder/GrammarBuilderExtensions.cs
@@ -209,7 +209,7 @@ public static class GrammarBuilderExtensions
     /// scope. The reason for this change is that the previous behavior had limited utility and lots
     /// of edge cases that were difficult to define and handle.
     /// </remarks>
-    public static IGrammarBuilder WithOperatorScope(this IGrammarBuilder builder, OperatorScope value)
+    public static IGrammarBuilder WithOperatorScope(this IGrammarBuilder builder, params OperatorScope value)
     {
         ArgumentNullExceptionCompat.ThrowIfNull(value);
 
@@ -219,7 +219,7 @@ public static class GrammarBuilderExtensions
     }
 
     /// <inheritdoc cref="WithOperatorScope"/>
-    public static IGrammarBuilder<T> WithOperatorScope<T>(this IGrammarBuilder<T> builder, OperatorScope value)
+    public static IGrammarBuilder<T> WithOperatorScope<T>(this IGrammarBuilder<T> builder, params OperatorScope value)
     {
         ArgumentNullExceptionCompat.ThrowIfNull(value);
 

--- a/src/FarkleNeo/Builder/Nonterminal.cs
+++ b/src/FarkleNeo/Builder/Nonterminal.cs
@@ -44,7 +44,7 @@ public static class Nonterminal
     /// <param name="name">The nonterminal's name.</param>
     /// <param name="productions">The nonterminal's productions.</param>
     /// <exception cref="ArgumentException"><paramref name="productions"/> is empty.</exception>
-    public static IGrammarSymbol<T> Create<T>(string name, ReadOnlySpan<IProduction<T>> productions)
+    public static IGrammarSymbol<T> Create<T>(string name, params ReadOnlySpan<IProduction<T>> productions)
     {
         ArgumentNullExceptionCompat.ThrowIfNull(name);
         if (productions.IsEmpty)
@@ -93,7 +93,7 @@ public static class Nonterminal
     /// <param name="productions">The nonterminal's productions, represented as <see cref="ProductionBuilder"/>
     /// objects that have not been <c>Extend</c>ed or <c>Finish</c>ed.</param>
     /// <exception cref="ArgumentException"><paramref name="productions"/> is empty.</exception>
-    public static IGrammarSymbol CreateUntyped(string name, ReadOnlySpan<ProductionBuilder> productions)
+    public static IGrammarSymbol CreateUntyped(string name, params ReadOnlySpan<ProductionBuilder> productions)
     {
         ArgumentNullExceptionCompat.ThrowIfNull(name);
         if (productions.IsEmpty)
@@ -153,7 +153,7 @@ public sealed class Nonterminal<T> : INonterminal, IGrammarSymbol<T>
     /// <exception cref="InvalidOperationException">The productions have already been successfully set.</exception>
     /// <remarks>This function and its overloads must be called exactly once, and before the
     /// nonterminal is used in building a grammar.</remarks>
-    public void SetProductions(ReadOnlySpan<IProduction<T>> productions)
+    public void SetProductions(params ReadOnlySpan<IProduction<T>> productions)
     {
         var builder = ImmutableArray.CreateBuilder<IProduction>(productions.Length);
         foreach (var production in productions)

--- a/src/FarkleNeo/Builder/OperatorPrecedence/AssociativityGroup.cs
+++ b/src/FarkleNeo/Builder/OperatorPrecedence/AssociativityGroup.cs
@@ -13,7 +13,7 @@ namespace Farkle.Builder.OperatorPrecedence;
 public class AssociativityGroup
 {
     /// <summary>
-    /// The <see cref="OperatorPrecedence.AssociativityType"/> of the group.
+    /// The <see cref="OperatorPrecedence.AssociativityType"/> of this group.
     /// </summary>
     public AssociativityType AssociativityType { get; }
 
@@ -46,7 +46,9 @@ public class AssociativityGroup
     /// <summary>
     /// Creates an <see cref="AssociativityGroup"/>.
     /// </summary>
-    public AssociativityGroup(AssociativityType associativityType, ImmutableArray<object> symbols)
+    /// <param name="associativityType">The <see cref="OperatorPrecedence.AssociativityType"/> of the group.</param>
+    /// <param name="symbols">The symbols that belong to the group.</param>
+    public AssociativityGroup(AssociativityType associativityType, params ImmutableArray<object> symbols)
     {
         ValidateAssociativityType(associativityType);
         if (symbols.IsDefault)
@@ -57,9 +59,7 @@ public class AssociativityGroup
         Symbols = symbols;
     }
 
-    /// <summary>
-    /// Creates an <see cref="AssociativityGroup"/>.
-    /// </summary>
+    /// <inheritdoc cref="AssociativityGroup(OperatorPrecedence.AssociativityType, System.Collections.Immutable.ImmutableArray{object})"/>
     public AssociativityGroup(AssociativityType associativityType, params object[] symbols)
     {
         ValidateAssociativityType(associativityType);
@@ -73,26 +73,62 @@ public class AssociativityGroup
 /// Provides a shortcut to create <see cref="AssociativityGroup"/>s with
 /// <see cref="AssociativityType.NonAssociative"/> associativity.
 /// </summary>
-/// <param name="symbols">The symbols of the group.</param>
-public class NonAssociative(params object[] symbols) : AssociativityGroup(AssociativityType.NonAssociative, symbols);
+public sealed class NonAssociative : AssociativityGroup
+{
+    /// <summary>
+    /// Creates a <see cref="NonAssociative"/>.
+    /// </summary>
+    /// <param name="symbols">The symbols of the group.</param>
+    public NonAssociative(params ImmutableArray<object> symbols) : base(AssociativityType.NonAssociative, symbols) { }
+
+    /// <inheritdoc cref="NonAssociative(System.Collections.Immutable.ImmutableArray{object})"/>
+    public NonAssociative(params object[] symbols) : base(AssociativityType.NonAssociative, symbols) { }
+}
 
 /// <summary>
 /// Provides a shortcut to create <see cref="AssociativityGroup"/>s with
 /// <see cref="AssociativityType.LeftAssociative"/> associativity.
 /// </summary>
-/// <param name="symbols">The symbols of the group.</param>
-public class LeftAssociative(params object[] symbols) : AssociativityGroup(AssociativityType.LeftAssociative, symbols);
+public sealed class LeftAssociative : AssociativityGroup
+{
+    /// <summary>
+    /// Creates a <see cref="LeftAssociative"/>.
+    /// </summary>
+    /// <param name="symbols">The symbols of the group.</param>
+    public LeftAssociative(params ImmutableArray<object> symbols) : base(AssociativityType.LeftAssociative, symbols) { }
+
+    /// <inheritdoc cref="LeftAssociative(System.Collections.Immutable.ImmutableArray{object})"/>
+    public LeftAssociative(params object[] symbols) : base(AssociativityType.LeftAssociative, symbols) { }
+}
 
 /// <summary>
 /// Provides a shortcut to create <see cref="AssociativityGroup"/>s with
 /// <see cref="AssociativityType.RightAssociative"/> associativity.
 /// </summary>
-/// <param name="symbols">The symbols of the group.</param>
-public class RightAssociative(params object[] symbols) : AssociativityGroup(AssociativityType.RightAssociative, symbols);
+public sealed class RightAssociative : AssociativityGroup
+{
+    /// <summary>
+    /// Creates a <see cref="RightAssociative"/>.
+    /// </summary>
+    /// <param name="symbols">The symbols of the group.</param>
+    public RightAssociative(params ImmutableArray<object> symbols) : base(AssociativityType.RightAssociative, symbols) { }
+
+    /// <inheritdoc cref="RightAssociative(System.Collections.Immutable.ImmutableArray{object})"/>
+    public RightAssociative(params object[] symbols) : base(AssociativityType.RightAssociative, symbols) { }
+}
 
 /// <summary>
 /// Provides a shortcut to create <see cref="AssociativityGroup"/>s with
 /// <see cref="AssociativityType.PrecedenceOnly"/> associativity.
 /// </summary>
-/// <param name="symbols">The symbols of the group.</param>
-public class PrecedenceOnly(params object[] symbols) : AssociativityGroup(AssociativityType.PrecedenceOnly, symbols);
+public sealed class PrecedenceOnly : AssociativityGroup
+{
+    /// <summary>
+    /// Creates a <see cref="PrecedenceOnly"/>.
+    /// </summary>
+    /// <param name="symbols">The symbols of the group.</param>
+    public PrecedenceOnly(params ImmutableArray<object> symbols) : base(AssociativityType.PrecedenceOnly, symbols) { }
+
+    /// <inheritdoc cref="NonAssociative(System.Collections.Immutable.ImmutableArray{object})"/>
+    public PrecedenceOnly(params object[] symbols) : base(AssociativityType.PrecedenceOnly, symbols) { }
+}

--- a/src/FarkleNeo/Builder/OperatorPrecedence/AssociativityGroup.cs
+++ b/src/FarkleNeo/Builder/OperatorPrecedence/AssociativityGroup.cs
@@ -48,18 +48,14 @@ public class AssociativityGroup
     /// </summary>
     /// <param name="associativityType">The <see cref="OperatorPrecedence.AssociativityType"/> of the group.</param>
     /// <param name="symbols">The symbols that belong to the group.</param>
-    public AssociativityGroup(AssociativityType associativityType, params ImmutableArray<object> symbols)
+    public AssociativityGroup(AssociativityType associativityType, params ReadOnlySpan<object> symbols)
     {
         ValidateAssociativityType(associativityType);
-        if (symbols.IsDefault)
-        {
-            ThrowHelpers.ThrowArgumentNullException(nameof(symbols));
-        }
         AssociativityType = associativityType;
-        Symbols = symbols;
+        Symbols = symbols.ToImmutableArray();
     }
 
-    /// <inheritdoc cref="AssociativityGroup(OperatorPrecedence.AssociativityType, System.Collections.Immutable.ImmutableArray{object})"/>
+    /// <inheritdoc cref="AssociativityGroup(OperatorPrecedence.AssociativityType, ReadOnlySpan{object})"/>
     public AssociativityGroup(AssociativityType associativityType, params object[] symbols)
     {
         ValidateAssociativityType(associativityType);
@@ -79,9 +75,9 @@ public sealed class NonAssociative : AssociativityGroup
     /// Creates a <see cref="NonAssociative"/>.
     /// </summary>
     /// <param name="symbols">The symbols of the group.</param>
-    public NonAssociative(params ImmutableArray<object> symbols) : base(AssociativityType.NonAssociative, symbols) { }
+    public NonAssociative(params ReadOnlySpan<object> symbols) : base(AssociativityType.NonAssociative, symbols) { }
 
-    /// <inheritdoc cref="NonAssociative(System.Collections.Immutable.ImmutableArray{object})"/>
+    /// <inheritdoc cref="NonAssociative(ReadOnlySpan{object})"/>
     public NonAssociative(params object[] symbols) : base(AssociativityType.NonAssociative, symbols) { }
 }
 
@@ -95,9 +91,9 @@ public sealed class LeftAssociative : AssociativityGroup
     /// Creates a <see cref="LeftAssociative"/>.
     /// </summary>
     /// <param name="symbols">The symbols of the group.</param>
-    public LeftAssociative(params ImmutableArray<object> symbols) : base(AssociativityType.LeftAssociative, symbols) { }
+    public LeftAssociative(params ReadOnlySpan<object> symbols) : base(AssociativityType.LeftAssociative, symbols) { }
 
-    /// <inheritdoc cref="LeftAssociative(System.Collections.Immutable.ImmutableArray{object})"/>
+    /// <inheritdoc cref="LeftAssociative(ReadOnlySpan{object})"/>
     public LeftAssociative(params object[] symbols) : base(AssociativityType.LeftAssociative, symbols) { }
 }
 
@@ -111,9 +107,9 @@ public sealed class RightAssociative : AssociativityGroup
     /// Creates a <see cref="RightAssociative"/>.
     /// </summary>
     /// <param name="symbols">The symbols of the group.</param>
-    public RightAssociative(params ImmutableArray<object> symbols) : base(AssociativityType.RightAssociative, symbols) { }
+    public RightAssociative(params ReadOnlySpan<object> symbols) : base(AssociativityType.RightAssociative, symbols) { }
 
-    /// <inheritdoc cref="RightAssociative(System.Collections.Immutable.ImmutableArray{object})"/>
+    /// <inheritdoc cref="RightAssociative(ReadOnlySpan{object})"/>
     public RightAssociative(params object[] symbols) : base(AssociativityType.RightAssociative, symbols) { }
 }
 
@@ -127,8 +123,8 @@ public sealed class PrecedenceOnly : AssociativityGroup
     /// Creates a <see cref="PrecedenceOnly"/>.
     /// </summary>
     /// <param name="symbols">The symbols of the group.</param>
-    public PrecedenceOnly(params ImmutableArray<object> symbols) : base(AssociativityType.PrecedenceOnly, symbols) { }
+    public PrecedenceOnly(params ReadOnlySpan<object> symbols) : base(AssociativityType.PrecedenceOnly, symbols) { }
 
-    /// <inheritdoc cref="NonAssociative(System.Collections.Immutable.ImmutableArray{object})"/>
+    /// <inheritdoc cref="NonAssociative(ReadOnlySpan{object})"/>
     public PrecedenceOnly(params object[] symbols) : base(AssociativityType.PrecedenceOnly, symbols) { }
 }

--- a/src/FarkleNeo/Builder/OperatorPrecedence/AssociativityGroup.cs
+++ b/src/FarkleNeo/Builder/OperatorPrecedence/AssociativityGroup.cs
@@ -56,13 +56,7 @@ public class AssociativityGroup
     }
 
     /// <inheritdoc cref="AssociativityGroup(OperatorPrecedence.AssociativityType, ReadOnlySpan{object})"/>
-    public AssociativityGroup(AssociativityType associativityType, params object[] symbols)
-    {
-        ValidateAssociativityType(associativityType);
-        ArgumentNullExceptionCompat.ThrowIfNull(symbols);
-        AssociativityType = associativityType;
-        Symbols = [.. symbols];
-    }
+    public AssociativityGroup(AssociativityType associativityType, params object[] symbols) : this(associativityType, symbols.AsSpanChecked()) { }
 }
 
 /// <summary>

--- a/src/FarkleNeo/Builder/OperatorPrecedence/OperatorScope.cs
+++ b/src/FarkleNeo/Builder/OperatorPrecedence/OperatorScope.cs
@@ -42,7 +42,7 @@ public sealed class OperatorScope
     /// <param name="canResolveReduceReduceConflicts">The value of <see cref="CanResolveReduceReduceConflicts"/>.</param>
     /// <param name="associativityGroups">The <see cref="AssociativityGroup"/>s that will comprise the scope,
     /// in ascending order of precedence.</param>
-    public OperatorScope(bool canResolveReduceReduceConflicts, ImmutableArray<AssociativityGroup> associativityGroups)
+    public OperatorScope(bool canResolveReduceReduceConflicts, params ImmutableArray<AssociativityGroup> associativityGroups)
     {
         if (associativityGroups.IsDefault)
         {
@@ -56,12 +56,7 @@ public sealed class OperatorScope
         AssociativityGroups = associativityGroups;
     }
 
-    /// <summary>
-    /// Creates an <see cref="OperatorScope"/>.
-    /// </summary>
-    /// <param name="canResolveReduceReduceConflicts">The value of <see cref="CanResolveReduceReduceConflicts"/>.</param>
-    /// <param name="associativityGroups">The <see cref="AssociativityGroup"/>s that will comprise the scope,
-    /// in ascending order of precedence.</param>
+    /// <inheritdoc cref="OperatorScope(bool, System.Collections.Immutable.ImmutableArray{AssociativityGroup})"/>
     public OperatorScope(bool canResolveReduceReduceConflicts, params AssociativityGroup[] associativityGroups)
     {
         ArgumentNullExceptionCompat.ThrowIfNull(associativityGroups);
@@ -73,12 +68,11 @@ public sealed class OperatorScope
         AssociativityGroups = associativityGroups.ToImmutableArray();
     }
 
-    /// <summary>
-    /// Creates an <see cref="OperatorScope"/>.
-    /// </summary>
-    /// <param name="associativityGroups">The <see cref="AssociativityGroup"/>s that will comprise the scope,
-    /// in ascending order of precedence.</param>
+    /// <inheritdoc cref="OperatorScope(bool, System.Collections.Immutable.ImmutableArray{AssociativityGroup})"/>
     public OperatorScope(params AssociativityGroup[] associativityGroups) : this(false, associativityGroups) { }
+
+    /// <inheritdoc cref="OperatorScope(bool, System.Collections.Immutable.ImmutableArray{AssociativityGroup})"/>
+    public OperatorScope(params ImmutableArray<AssociativityGroup> associativityGroups) : this(false, associativityGroups) { }
 
 #if false
     // These APIs might not be necessary with https://github.com/dotnet/csharplang/pull/7895,

--- a/src/FarkleNeo/Builder/OperatorPrecedence/OperatorScope.cs
+++ b/src/FarkleNeo/Builder/OperatorPrecedence/OperatorScope.cs
@@ -48,15 +48,7 @@ public sealed class OperatorScope : IEnumerable<AssociativityGroup>
 
     /// <inheritdoc cref="OperatorScope(bool, ReadOnlySpan{AssociativityGroup})"/>
     public OperatorScope(bool canResolveReduceReduceConflicts, params AssociativityGroup[] associativityGroups)
-    {
-        ArgumentNullExceptionCompat.ThrowIfNull(associativityGroups);
-        for (int i = 0; i < associativityGroups.Length; i++)
-        {
-            ArgumentNullExceptionCompat.ThrowIfNull(associativityGroups[i]);
-        }
-        CanResolveReduceReduceConflicts = canResolveReduceReduceConflicts;
-        AssociativityGroups = associativityGroups.ToImmutableArray();
-    }
+        : this(canResolveReduceReduceConflicts, associativityGroups.AsSpanChecked()) { }
 
     /// <inheritdoc cref="OperatorScope(bool, ReadOnlySpan{AssociativityGroup})"/>
     public OperatorScope(params AssociativityGroup[] associativityGroups) : this(false, associativityGroups) { }

--- a/src/FarkleNeo/Builder/OperatorPrecedence/OperatorScope.cs
+++ b/src/FarkleNeo/Builder/OperatorPrecedence/OperatorScope.cs
@@ -13,17 +13,11 @@ namespace Farkle.Builder.OperatorPrecedence;
 /// ordered by precedence and can be used to resolve conflicts when building
 /// the parser state machine.
 /// </summary>
-#if false
-// Temporarily delaying collection expression support, see below.
 /// <remarks>
 /// An operator scope can be created with C# 12's collection expressions.
 /// </remarks>
 [CollectionBuilder(typeof(OperatorScope), nameof(Create))]
-#endif
-public sealed class OperatorScope
-#if false
-    : IEnumerable<AssociativityGroup>
-#endif
+public sealed class OperatorScope : IEnumerable<AssociativityGroup>
 {
     /// <summary>
     /// Whether the operator scope can be used to resolve reduce-reduce conflicts.
@@ -74,10 +68,6 @@ public sealed class OperatorScope
     /// <inheritdoc cref="OperatorScope(bool, System.Collections.Immutable.ImmutableArray{AssociativityGroup})"/>
     public OperatorScope(params ImmutableArray<AssociativityGroup> associativityGroups) : this(false, associativityGroups) { }
 
-#if false
-    // These APIs might not be necessary with https://github.com/dotnet/csharplang/pull/7895,
-    // let's wait a bit before adding collection expressions support.
-
     /// <summary>
     /// Factory method to enable creating operator scopes using collection expressions.
     /// </summary>
@@ -85,14 +75,12 @@ public sealed class OperatorScope
     public static OperatorScope Create(ReadOnlySpan<AssociativityGroup> associativityGroups) =>
         new(false, associativityGroups.ToImmutableArray());
 
-    /// <summary>
-    /// Gets an enumerator for the scope's associativity groups.
-    /// </summary>
-    public ImmutableArray<AssociativityGroup>.Enumerator GetEnumerator() => AssociativityGroups.GetEnumerator();
+    // An optimized GetEnumerator() that returns an immutable array enumerator will not
+    // be provided at the moment due to the lack of use cases. It can be added in the future
+    // if needed.
 
     IEnumerator<AssociativityGroup> IEnumerable<AssociativityGroup>.GetEnumerator() =>
         ((IEnumerable<AssociativityGroup>)AssociativityGroups).GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)AssociativityGroups).GetEnumerator();
-#endif
 }

--- a/src/FarkleNeo/Builder/OperatorPrecedence/OperatorScope.cs
+++ b/src/FarkleNeo/Builder/OperatorPrecedence/OperatorScope.cs
@@ -25,7 +25,7 @@ public sealed class OperatorScope : IEnumerable<AssociativityGroup>
     /// <remarks>
     /// This capability is not enabled by default.
     /// </remarks>
-    /// <seealso cref="OperatorScope(bool, ImmutableArray{AssociativityGroup})"/>
+    /// <seealso cref="OperatorScope(bool, ReadOnlySpan{AssociativityGroup})"/>
     public bool CanResolveReduceReduceConflicts { get; }
 
     internal ImmutableArray<AssociativityGroup> AssociativityGroups { get; }
@@ -36,21 +36,17 @@ public sealed class OperatorScope : IEnumerable<AssociativityGroup>
     /// <param name="canResolveReduceReduceConflicts">The value of <see cref="CanResolveReduceReduceConflicts"/>.</param>
     /// <param name="associativityGroups">The <see cref="AssociativityGroup"/>s that will comprise the scope,
     /// in ascending order of precedence.</param>
-    public OperatorScope(bool canResolveReduceReduceConflicts, params ImmutableArray<AssociativityGroup> associativityGroups)
+    public OperatorScope(bool canResolveReduceReduceConflicts, params ReadOnlySpan<AssociativityGroup> associativityGroups)
     {
-        if (associativityGroups.IsDefault)
-        {
-            ThrowHelpers.ThrowArgumentNullException(nameof(associativityGroups));
-        }
         for (int i = 0; i < associativityGroups.Length; i++)
         {
             ArgumentNullExceptionCompat.ThrowIfNull(associativityGroups[i]);
         }
         CanResolveReduceReduceConflicts = canResolveReduceReduceConflicts;
-        AssociativityGroups = associativityGroups;
+        AssociativityGroups = associativityGroups.ToImmutableArray();
     }
 
-    /// <inheritdoc cref="OperatorScope(bool, System.Collections.Immutable.ImmutableArray{AssociativityGroup})"/>
+    /// <inheritdoc cref="OperatorScope(bool, ReadOnlySpan{AssociativityGroup})"/>
     public OperatorScope(bool canResolveReduceReduceConflicts, params AssociativityGroup[] associativityGroups)
     {
         ArgumentNullExceptionCompat.ThrowIfNull(associativityGroups);
@@ -62,18 +58,17 @@ public sealed class OperatorScope : IEnumerable<AssociativityGroup>
         AssociativityGroups = associativityGroups.ToImmutableArray();
     }
 
-    /// <inheritdoc cref="OperatorScope(bool, System.Collections.Immutable.ImmutableArray{AssociativityGroup})"/>
+    /// <inheritdoc cref="OperatorScope(bool, ReadOnlySpan{AssociativityGroup})"/>
     public OperatorScope(params AssociativityGroup[] associativityGroups) : this(false, associativityGroups) { }
 
-    /// <inheritdoc cref="OperatorScope(bool, System.Collections.Immutable.ImmutableArray{AssociativityGroup})"/>
-    public OperatorScope(params ImmutableArray<AssociativityGroup> associativityGroups) : this(false, associativityGroups) { }
+    /// <inheritdoc cref="OperatorScope(bool, ReadOnlySpan{AssociativityGroup})"/>
+    public OperatorScope(params ReadOnlySpan<AssociativityGroup> associativityGroups) : this(false, associativityGroups) { }
 
     /// <summary>
     /// Factory method to enable creating operator scopes using collection expressions.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static OperatorScope Create(ReadOnlySpan<AssociativityGroup> associativityGroups) =>
-        new(false, associativityGroups.ToImmutableArray());
+    public static OperatorScope Create(ReadOnlySpan<AssociativityGroup> associativityGroups) => new(associativityGroups);
 
     // An optimized GetEnumerator() that returns an immutable array enumerator will not
     // be provided at the moment due to the lack of use cases. It can be added in the future

--- a/src/FarkleNeo/Builder/ProductionBuilder.cs
+++ b/src/FarkleNeo/Builder/ProductionBuilder.cs
@@ -34,7 +34,7 @@ public sealed class ProductionBuilder : IProductionBuilder<ProductionBuilder>, I
     /// <summary>
     /// A production builder with no members.
     /// </summary>
-    public static ProductionBuilder Empty { get; } = new([]);
+    public static ProductionBuilder Empty { get; } = new();
 
     private ProductionBuilder(ImmutableList<IGrammarSymbol> members, object? precedenceToken = null)
     {

--- a/src/FarkleNeo/Builder/Regex.cs
+++ b/src/FarkleNeo/Builder/Regex.cs
@@ -317,7 +317,7 @@ public sealed class Regex
     /// of specific ones.
     /// </summary>
     /// <param name="chars">An immutable array with characters.</param>
-    public static Regex NotOneOf(ImmutableArray<char> chars)
+    public static Regex NotOneOf(params ImmutableArray<char> chars)
     {
         char[]? arrayUnsafe = ImmutableCollectionsMarshal.AsArray(chars);
         ArgumentNullExceptionCompat.ThrowIfNull(arrayUnsafe, nameof(chars));
@@ -338,7 +338,7 @@ public sealed class Regex
     /// inclusive.</param>
     /// <exception cref="ArgumentException">A range's start is greater
     /// than its end.</exception>
-    public static Regex NotOneOf(ImmutableArray<(char, char)> ranges)
+    public static Regex NotOneOf(params ImmutableArray<(char, char)> ranges)
     {
         (char, char)[]? arrayUnsafe = ImmutableCollectionsMarshal.AsArray(ranges);
         ArgumentNullExceptionCompat.ThrowIfNull(arrayUnsafe, nameof(ranges));
@@ -361,7 +361,7 @@ public sealed class Regex
     /// a regex that cannot match anything. This is usually not desirable
     /// and will result in a build-time warning.
     /// </remarks>
-    public static Regex OneOf(ImmutableArray<char> chars)
+    public static Regex OneOf(params ImmutableArray<char> chars)
     {
         char[]? arrayUnsafe = ImmutableCollectionsMarshal.AsArray(chars);
         ArgumentNullExceptionCompat.ThrowIfNull(arrayUnsafe, nameof(chars));
@@ -386,7 +386,7 @@ public sealed class Regex
     /// a regex that cannot match anything. This is usually not desirable
     /// and will result in a build-time warning.
     /// </remarks>
-    public static Regex OneOf(ImmutableArray<(char, char)> ranges)
+    public static Regex OneOf(params ImmutableArray<(char, char)> ranges)
     {
         (char, char)[]? arrayUnsafe = ImmutableCollectionsMarshal.AsArray(ranges);
         ArgumentNullExceptionCompat.ThrowIfNull(arrayUnsafe, nameof(ranges));
@@ -404,7 +404,7 @@ public sealed class Regex
     /// Creates a <see cref="Regex"/> that matches many regexes in sequence.
     /// </summary>
     /// <param name="regexes">An immutable array of regexes.</param>
-    public static Regex Join(ImmutableArray<Regex> regexes)
+    public static Regex Join(params ImmutableArray<Regex> regexes)
     {
         Regex[]? arrayUnsafe = ImmutableCollectionsMarshal.AsArray(regexes);
         ArgumentNullExceptionCompat.ThrowIfNull(arrayUnsafe, nameof(regexes));
@@ -428,7 +428,7 @@ public sealed class Regex
     /// a regex that cannot match anything. This is usually not desirable
     /// and will result in a build-time warning.
     /// </remarks>
-    public static Regex Choice(ImmutableArray<Regex> regexes)
+    public static Regex Choice(params ImmutableArray<Regex> regexes)
     {
         Regex[]? arrayUnsafe = ImmutableCollectionsMarshal.AsArray(regexes);
         ArgumentNullExceptionCompat.ThrowIfNull(arrayUnsafe, nameof(regexes));

--- a/src/FarkleNeo/Builder/Regex.cs
+++ b/src/FarkleNeo/Builder/Regex.cs
@@ -247,7 +247,7 @@ public sealed class Regex
     /// <summary>
     /// A <see cref="Regex"/> that matches a specific character.
     /// </summary>
-    public static Regex Literal(char c) => OneOf([(c, c)]);
+    public static Regex Literal(char c) => OneOf((c, c));
 
     /// <summary>
     /// A <see cref="Regex"/> that matches a specific string of characters.
@@ -570,7 +570,7 @@ public sealed class Regex
                 return Literal(leftString + rightString);
             }
         }
-        return Join([left, right]);
+        return Join(left, right);
     }
 
     /// <summary>
@@ -613,7 +613,7 @@ public sealed class Regex
                 return OneOf([.. leftChars, .. rightChars]);
             }
         }
-        return Choice([left, right]);
+        return Choice(left, right);
     }
 
     [Flags]

--- a/src/FarkleNeo/Builder/RegexGrammar.cs
+++ b/src/FarkleNeo/Builder/RegexGrammar.cs
@@ -178,7 +178,7 @@ internal static class RegexGrammar
         var numbersRegex = Regex.OneOf(numbers).AtLeast(1);
 
         var quantRepeat = Terminal.Create("Repeat quantifier",
-            Regex.Join([Regex.Literal('{'), numbersRegex, Regex.Literal('}')]),
+            Regex.Join(Regex.Literal('{'), numbersRegex, Regex.Literal('}')),
             (ref ParserState _, ReadOnlySpan<char> data) =>
             {
                 var count = ParseInt(data[1..^1]);
@@ -186,7 +186,7 @@ internal static class RegexGrammar
             });
 
         var quantAtLeast = Terminal.Create("At least quantifier",
-            Regex.Join([Regex.Literal('{'), numbersRegex, Regex.Literal(",}")]),
+            Regex.Join(Regex.Literal('{'), numbersRegex, Regex.Literal(",}")),
             (ref ParserState _, ReadOnlySpan<char> data) =>
             {
                 var count = ParseInt(data[1..^2]);
@@ -194,7 +194,7 @@ internal static class RegexGrammar
             });
 
         var quantBetween = Terminal.Create("Between quantifier",
-            Regex.Join([Regex.Literal('{'), numbersRegex, Regex.Literal(','), numbersRegex, Regex.Literal('}')]),
+            Regex.Join(Regex.Literal('{'), numbersRegex, Regex.Literal(','), numbersRegex, Regex.Literal('}')),
             (ref ParserState _, ReadOnlySpan<char> data) =>
             {
                 data = data[1..^1];
@@ -259,7 +259,7 @@ internal static class RegexGrammar
 
         static IGrammarSymbol<Regex> MakePredefinedSet(string name, string start) =>
             Terminal.Create<Regex>(name,
-                Regex.Join([Regex.Literal(start), Regex.NotOneOf(['{', '}']).AtLeast(1), Regex.Literal('}')]),
+                Regex.Join(Regex.Literal(start), Regex.NotOneOf('{', '}').AtLeast(1), Regex.Literal('}')),
                 (ref ParserState _, ReadOnlySpan<char> _) =>
                     throw CreateLocalizedException(nameof(Resources.Builder_RegexStringPredefinedSetsNotSupported)),
                 TerminalOptions.Hidden);
@@ -268,7 +268,7 @@ internal static class RegexGrammar
             Terminal.Create<Regex>(name,
                 // According to https://www.regular-expressions.info/unicode.html,
                 // this syntax accepts only single-letter categories.
-                Regex.Literal(start) + Regex.OneOf([('A', 'Z')]),
+                Regex.Literal(start) + Regex.OneOf(('A', 'Z')),
                 (ref ParserState _, ReadOnlySpan<char> _) =>
                     throw CreateLocalizedException(nameof(Resources.Builder_RegexStringUnicodeCategoriesNotSupported)),
                 TerminalOptions.Hidden);
@@ -278,24 +278,24 @@ internal static class RegexGrammar
             // Should we also support shorthand escape sequences inside character sets like [\da-z]?
             // On first sight not, because it will increase complexity of the transformer, with minimal benefit.
             // When we support Unicode categories in the future, we can revisit this.
-            Regex escapedChar = Regex.Literal('\\') + Regex.OneOf(['\\', ']', '^', '-']);
+            Regex escapedChar = Regex.Literal('\\') + Regex.OneOf('\\', ']', '^', '-');
             return Terminal.Create(name,
-                Regex.Join([
+                Regex.Join(
                     Regex.Literal(start),
                     // The first character can also be an unescaped closing bracket (making []] valid),
                     // but cannot be a caret in non-negated sets (to resolve the ambiguity with
                     // negated sets).
-                    Regex.Choice([
+                    Regex.Choice(
                         escapedChar,
                         Regex.NotOneOf(start.EndsWith("^") ? ['\\'] : ['\\', '^'])
-                    ]),
+                    ),
                     // Subsequent characters can be anything except an unescaped closing bracket.
-                    Regex.Choice([
+                    Regex.Choice(
                         escapedChar,
                         Regex.NotOneOf(['\\', ']'])
-                    ]).ZeroOrMore(),
+                    ).ZeroOrMore(),
                     Regex.Literal(']')
-                ]),
+                ),
                 (ref ParserState state, ReadOnlySpan<char> data) =>
                     fChars(ParseCharacterSet(in state, data, start.Length)));
         }

--- a/src/FarkleNeo/Builder/RegexGrammar.cs
+++ b/src/FarkleNeo/Builder/RegexGrammar.cs
@@ -292,7 +292,7 @@ internal static class RegexGrammar
                     // Subsequent characters can be anything except an unescaped closing bracket.
                     Regex.Choice(
                         escapedChar,
-                        Regex.NotOneOf(['\\', ']'])
+                        Regex.NotOneOf('\\', ']')
                     ).ZeroOrMore(),
                     Regex.Literal(']')
                 ),

--- a/src/FarkleNeo/Builder/Terminals.cs
+++ b/src/FarkleNeo/Builder/Terminals.cs
@@ -19,23 +19,23 @@ namespace Farkle.Builder;
 /// </summary>
 public static class Terminals
 {
-    private static readonly Regex s_unsignedIntRegex = Regex.OneOf([('0', '9')]).AtLeast(1);
+    private static readonly Regex s_unsignedIntRegex = Regex.OneOf(('0', '9')).AtLeast(1);
 
-    private static readonly Regex s_intRegex = Regex.OneOf([('-', '-')]).Optional() + s_unsignedIntRegex;
+    private static readonly Regex s_intRegex = Regex.OneOf(('-', '-')).Optional() + s_unsignedIntRegex;
 
-    private static readonly Regex s_unsignedFloatRegex = Regex.Join([
-        Regex.OneOf([('-', '-')]).Optional(),
+    private static readonly Regex s_unsignedFloatRegex = Regex.Join(
+        Regex.OneOf(('-', '-')).Optional(),
         s_unsignedIntRegex,
-        Regex.OneOf(['.']),
+        Regex.OneOf('.'),
         s_unsignedIntRegex,
-        Regex.Join([
-            Regex.OneOf(['e', 'E']),
-            Regex.OneOf(['+', '-']).Optional(),
+        Regex.Join(
+            Regex.OneOf('e', 'E'),
+            Regex.OneOf('+', '-').Optional(),
             s_unsignedIntRegex
-        ]).Optional()
-    ]);
+        ).Optional()
+    );
 
-    private static readonly Regex s_signedFloatRegex = Regex.OneOf(['-', '-']).Optional() + s_unsignedFloatRegex;
+    private static readonly Regex s_signedFloatRegex = Regex.OneOf('-', '-').Optional() + s_unsignedFloatRegex;
 
     // Helper method that returns either a string or a ReadOnlySpan<char> depending on the target framework.
     // This method is intended to be used for the framework's parsing methods.
@@ -311,27 +311,27 @@ public static class Terminals
         var regexDelimiter = Regex.Literal(delimiter);
         var regexBackslash = Regex.Literal('\\');
         var regex =
-            Regex.Join([
+            Regex.Join(
                 regexDelimiter,
-                Regex.Choice([
+                Regex.Choice(
                     Regex.NotOneOf(multiLine ? ['\n', '\r', '\\', delimiter] : ['\\', delimiter]),
-                    Regex.Join([
+                    Regex.Join(
                         regexBackslash,
-                        Regex.Choice([
+                        Regex.Choice(
                             regexBackslash,
                             regexDelimiter,
                             Regex.OneOf(escapeChars.ToImmutableArray()),
                             allowEscapeUnicode
-                                ? Regex.Join([
+                                ? Regex.Join(
                                     Regex.Literal('u'),
-                                    Regex.OneOf([('0', '9'), ('a', 'f'), ('A', 'F')]).Repeat(4)
-                                ])
+                                    Regex.OneOf(('0', '9'), ('a', 'f'), ('A', 'F')).Repeat(4)
+                                )
                                 : Regex.Empty
-                        ])
-                    ])
-                ]).ZeroOrMore(),
+                        )
+                    )
+                ).ZeroOrMore(),
                 regexDelimiter
-            ]).CaseSensitive();
+            ).CaseSensitive();
 
         return Terminal.Create(name, regex, TransformString);
     }

--- a/src/FarkleNeo/Builder/Untyped.cs
+++ b/src/FarkleNeo/Builder/Untyped.cs
@@ -64,7 +64,7 @@ public sealed class Nonterminal : INonterminal
     /// <exception cref="InvalidOperationException">The productions have already been successfully set.</exception>
     /// <remarks>This function and its overloads must be called exactly once, and before the
     /// nonterminal is used in building a grammar.</remarks>
-    public void SetProductions(ReadOnlySpan<ProductionBuilder> productions) =>
+    public void SetProductions(params ReadOnlySpan<ProductionBuilder> productions) =>
         SetProductions(ImmutableArray<IProduction>.CastUp(productions.ToImmutableArray()));
 
     internal void SetProductions(ImmutableArray<IProduction> productions)

--- a/src/FarkleNeo/CharParser.cs
+++ b/src/FarkleNeo/CharParser.cs
@@ -181,7 +181,7 @@ public abstract class CharParser<T> : IParser<char, T>
     /// <remarks>
     /// In certain failing parsers this method will have no effect and return <see langword="this"/>.
     /// </remarks>
-    public CharParser<T> WithTokenizerChain(ReadOnlySpan<ChainedTokenizerComponent<char>> components)
+    public CharParser<T> WithTokenizerChain(params ReadOnlySpan<ChainedTokenizerComponent<char>> components)
     {
         return WithTokenizerChainCore(components);
     }

--- a/src/FarkleNeo/CharParser.cs
+++ b/src/FarkleNeo/CharParser.cs
@@ -169,7 +169,7 @@ public abstract class CharParser<T> : IParser<char, T>
     public CharParser<T> WithTokenizer(Func<IGrammarProvider, Tokenizer<char>> tokenizerFactory)
     {
         ArgumentNullExceptionCompat.ThrowIfNull(tokenizerFactory);
-        return WithTokenizerChain([ChainedTokenizerComponent<char>.Create(tokenizerFactory)]);
+        return WithTokenizerChain(ChainedTokenizerComponent<char>.Create(tokenizerFactory));
     }
 
     /// <summary>

--- a/src/FarkleNeo/FarkleNeo.csproj
+++ b/src/FarkleNeo/FarkleNeo.csproj
@@ -2,7 +2,7 @@
   <Import Project="../NuGet.props" />
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>13</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Nullable Condition="'$(TargetFramework)' == 'netstandard2.0'">annotations</Nullable>

--- a/src/FarkleNeo/FarkleNeo.csproj
+++ b/src/FarkleNeo/FarkleNeo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../NuGet.props" />
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/FarkleNeo/FarkleNeo.csproj
+++ b/src/FarkleNeo/FarkleNeo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../NuGet.props" />
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/FarkleNeo/Utilities.cs
+++ b/src/FarkleNeo/Utilities.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Farkle;
@@ -13,6 +14,16 @@ internal static class Utilities
     {
         Debug.Assert(o is T);
         return Unsafe.As<T>(o);
+    }
+
+    /// <summary>
+    /// Converts an array to a span, while throwing if it is null.
+    /// </summary>
+    public static Span<T> AsSpanChecked<T>([NotNull] this T[]? array,
+        [CallerArgumentExpression((nameof(array)))] string? paramName = null)
+    {
+        ArgumentNullExceptionCompat.ThrowIfNull(array, paramName);
+        return array.AsSpan();
     }
 
     /// <summary>

--- a/tests/Farkle.Benchmarks/Farkle.Benchmarks.fsproj
+++ b/tests/Farkle.Benchmarks/Farkle.Benchmarks.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\FarkleNeo\FarkleNeo.csproj" />

--- a/tests/Farkle.Tests.CSharp/Farkle.Tests.CSharp.csproj
+++ b/tests/Farkle.Tests.CSharp/Farkle.Tests.CSharp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">net8.0;net48</TargetFrameworks>
     <TargetFramework Condition="!$([MSBuild]::IsOsPlatform('Windows'))">net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>13</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Farkle.Tests.CSharp/OperatorScopeConflictResolverTests.cs
+++ b/tests/Farkle.Tests.CSharp/OperatorScopeConflictResolverTests.cs
@@ -44,8 +44,8 @@ internal class OperatorScopeConflictResolverTests
     public void TestDifferentPrecedence(bool reduceFirst, LrConflictResolverDecision expectedDecision)
     {
         OperatorScope operators = reduceFirst
-            ? new(new LeftAssociative(_production1Token), new LeftAssociative(_terminal1))
-            : new(new LeftAssociative(_terminal1), new LeftAssociative(_production1Token));
+            ? [new LeftAssociative(_production1Token), new LeftAssociative(_terminal1)]
+            : [new LeftAssociative(_terminal1), new LeftAssociative(_production1Token)];
         var resolver = new OperatorScopeConflictResolver(operators, _objectMap, true);
 
         LrConflictResolverDecision decision = resolver.ResolveShiftReduceConflict(_terminal1Handle, _production1Handle);
@@ -60,7 +60,7 @@ internal class OperatorScopeConflictResolverTests
     [TestCase(AssociativityType.PrecedenceOnly, LrConflictResolverDecision.CannotChoose)]
     public void TestSamePrecedence(AssociativityType associativityType, LrConflictResolverDecision expectedDecision)
     {
-        OperatorScope operators = new(new AssociativityGroup(associativityType, _terminal1, _production1Token));
+        OperatorScope operators = [new AssociativityGroup(associativityType, _terminal1, _production1Token)];
         var resolver = new OperatorScopeConflictResolver(operators, _objectMap, true);
 
         LrConflictResolverDecision decision = resolver.ResolveShiftReduceConflict(_terminal1Handle, _production1Handle);
@@ -95,7 +95,7 @@ internal class OperatorScopeConflictResolverTests
     [Test]
     public void TestReduceReduceUnsupported()
     {
-        OperatorScope operators = new(new PrecedenceOnly(_production1Token), new PrecedenceOnly(_production2Token));
+        OperatorScope operators = [new PrecedenceOnly(_production1Token), new PrecedenceOnly(_production2Token)];
         var resolver = new OperatorScopeConflictResolver(operators, _objectMap, true);
 
         LrConflictResolverDecision decision = resolver.ResolveReduceReduceConflict(_production1Handle, _production2Handle);
@@ -112,7 +112,7 @@ internal class OperatorScopeConflictResolverTests
     {
         const string literal1 = nameof(literal1);
         const string literal2 = nameof(literal2);
-        OperatorScope operators = new(new PrecedenceOnly(literal1), new PrecedenceOnly(Terminal.Literal(literal2)));
+        OperatorScope operators = [new PrecedenceOnly(literal1), new PrecedenceOnly(Terminal.Literal(literal2))];
         var objectMap = new Dictionary<EntityHandle, object>
         {
             [_terminal1Handle] = Terminal.Literal(caseSensitive ? literal1 : literal1.ToUpperInvariant()),

--- a/tests/Farkle.Tests/Farkle.Tests.fsproj
+++ b/tests/Farkle.Tests/Farkle.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <!-- Using "new" to create disposable types. -->
     <NoWarn>$(NoWarn);FS0760</NoWarn>

--- a/tests/Farkle.Tools.MSBuild.Tests/Farkle.Tools.MSBuild.Tests.csproj
+++ b/tests/Farkle.Tools.MSBuild.Tests/Farkle.Tools.MSBuild.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <FarkleGenerateHtml>true</FarkleGenerateHtml>


### PR DESCRIPTION
This enables us to use `params` collections thoughout the library.