### PR TITLE
Add Hot Reload APIs.

### DIFF
--- a/src/FarkleNeo/Collections/ConditionalWeakList.cs
+++ b/src/FarkleNeo/Collections/ConditionalWeakList.cs
@@ -1,0 +1,34 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+#if NET6_0_OR_GREATER
+using System.Collections;
+using System.Runtime.CompilerServices;
+
+namespace Farkle.Collections;
+
+/// <summary>
+/// Stores a list of weak references to objects.
+/// </summary>
+internal sealed class ConditionalWeakList<T> : IEnumerable<T> where T : class
+{
+    // This could use a list or array of weak references, but it's not very important
+    // to optimize, considering the development-only nature of Hot Reload.
+    private readonly ConditionalWeakTable<T, object> _container = [];
+
+    public void Add(T item)
+    {
+        _container.Add(item, item);
+    }
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        foreach (var entry in _container)
+        {
+            yield return entry.Key;
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+#endif

--- a/src/FarkleNeo/HotReload/IMetadataUpdatable.cs
+++ b/src/FarkleNeo/HotReload/IMetadataUpdatable.cs
@@ -6,7 +6,6 @@ namespace Farkle.HotReload;
 /// <summary>
 /// Provides an interface to listen for Hot Reload events.
 /// </summary>
-/// <seealso cref="MetadataUpdatableManager"/>
 internal interface IMetadataUpdatable
 {
     /// <summary>

--- a/src/FarkleNeo/HotReload/IMetadataUpdatable.cs
+++ b/src/FarkleNeo/HotReload/IMetadataUpdatable.cs
@@ -1,0 +1,18 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+namespace Farkle.HotReload;
+
+/// <summary>
+/// Provides an interface to listen for Hot Reload events.
+/// </summary>
+/// <seealso cref="MetadataUpdatableManager"/>
+internal interface IMetadataUpdatable
+{
+    /// <summary>
+    /// Clears an object's internal caches after a metadata update.
+    /// </summary>
+    void ClearCache();
+
+    // We don't need an UpdateApplication method at the moment.
+}

--- a/src/FarkleNeo/HotReload/MetadataUpdatableManager.cs
+++ b/src/FarkleNeo/HotReload/MetadataUpdatableManager.cs
@@ -1,0 +1,47 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+#if NET6_0_OR_GREATER
+using System.Reflection.Metadata;
+using System.Runtime.CompilerServices;
+using Farkle.Collections;
+
+[assembly: MetadataUpdateHandler(typeof(Farkle.HotReload.MetadataUpdatableManager))]
+
+namespace Farkle.HotReload;
+
+/// <summary>
+/// Receives Hot Reload events and dispatches them to <see cref="IMetadataUpdatable"/> objects.
+/// </summary>
+internal static class MetadataUpdatableManager
+{
+    private static readonly ConditionalWeakTable<Type, ConditionalWeakList<IMetadataUpdatable>> s_items = [];
+
+    /// <summary>
+    /// Registers an <see cref="IMetadataUpdatable"/> object to
+    /// receive Hot Reload events on the given <see cref="Type"/>.
+    /// </summary>
+    /// <remarks>
+    /// Neither <paramref name="type"/> nor <paramref name="item"/>
+    /// are kept alive by this method.
+    /// </remarks>
+    public static void Register(Type type, IMetadataUpdatable item)
+    {
+        s_items.GetOrCreateValue(type).Add(item);
+    }
+
+    private static IEnumerable<IMetadataUpdatable> GetAllItems() =>
+        s_items.SelectMany(x => x.Value);
+
+    private static IEnumerable<IMetadataUpdatable> GetItems(Type[] types) =>
+        types.SelectMany(x => s_items.TryGetValue(x, out var items) ? items.AsEnumerable() : []);
+
+    public static void ClearCache(Type[]? types)
+    {
+        foreach (IMetadataUpdatable item in types is null ? GetAllItems() : GetItems(types))
+        {
+            item.ClearCache();
+        }
+    }
+}
+#endif

--- a/src/FarkleNeo/HotReload/MetadataUpdatableParser.cs
+++ b/src/FarkleNeo/HotReload/MetadataUpdatableParser.cs
@@ -1,0 +1,146 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+using Farkle.Grammars;
+using Farkle.Parser;
+using Farkle.Parser.Semantics;
+using Farkle.Parser.Tokenizers;
+
+namespace Farkle.HotReload;
+
+/// <summary>
+/// Provides a <see cref="CharParser{T}"/> that wraps a <see cref="CharParser{T}"/>
+/// created from a factory function, and refreshes it when Hot Reload is performed.
+/// </summary>
+/// <typeparam name="T">The parser's result type.</typeparam>
+/// <typeparam name="TOriginal">The original parser's result type, before changing its semantic provider.</typeparam>
+internal sealed class MetadataUpdatableParser<T, TOriginal> : CharParser<T>, IMetadataUpdatable, IParserStateContextFactory<char, T>
+{
+    /// <summary>
+    /// The <see cref="Type"/> to key Hot Reload event notifications on.
+    /// </summary>
+    private readonly Type _metadataUpdateKey;
+
+    /// <summary>
+    /// The factory for the original parser.
+    /// </summary>
+    /// <remarks>
+    /// It is assumed that calling this function will build a parser and take a lot of time,
+    /// so it is only called when needed. If the original parser has not been invalidated,
+    /// customizing the parser will not cause it to be rebuilt.
+    /// </remarks>
+    private readonly Func<CharParser<TOriginal>> _parserFactory;
+
+    /// <summary>
+    /// A function that potentially changes the tokenizer of the original parser.
+    /// </summary>
+    /// <remarks>
+    /// It is assumed that calling this function is fast. The initial value of this field
+    /// is the identity function.
+    /// </remarks>
+    private readonly Func<CharParser<TOriginal>, CharParser<TOriginal>> _tokenizerEnricher;
+
+    /// <summary>
+    /// A function that potentially changes the semantic provider of the original parser,
+    /// and its return type.
+    /// </summary>
+    /// <remarks>
+    /// It is assumed that calling this function is fast. The initial value of this field
+    /// is the identity function.
+    /// </remarks>
+    private readonly Func<CharParser<TOriginal>, CharParser<T>> _semanticProviderEnricher;
+
+    /// <summary>
+    /// A tuple that holds the original and the transformed parser.
+    /// </summary>
+    /// <remarks>
+    /// This is a reference tuple to support atomically clearing both when
+    /// Hot Reload is performed.
+    /// </remarks>
+    private volatile Tuple<CharParser<TOriginal>, CharParser<T>>? _parser;
+
+    private CharParser<T> TransformParser(CharParser<TOriginal> parser) =>
+        _semanticProviderEnricher(_tokenizerEnricher(parser));
+
+    private CharParser<T> GetParser()
+    {
+        return _parser?.Item2 ?? CreateParser();
+
+        CharParser<T> CreateParser()
+        {
+            var parser = _parserFactory();
+            var transformedParser = TransformParser(parser);
+            Interlocked.CompareExchange(ref _parser, Tuple.Create(parser, transformedParser), null);
+            return _parser.Item2;
+        }
+    }
+
+    private CharParser<T> WithTokenizerEnricher(Func<CharParser<TOriginal>, CharParser<TOriginal>> fTokenizer) =>
+        new MetadataUpdatableParser<T, TOriginal>(_metadataUpdateKey, _parserFactory, fTokenizer, _semanticProviderEnricher, _parser?.Item1);
+
+    private CharParser<TNew> WithSemanticProviderEnricher<TNew>(Func<CharParser<TOriginal>, CharParser<TNew>> fSemanticProvider) =>
+        new MetadataUpdatableParser<TNew, TOriginal>(_metadataUpdateKey, _parserFactory, _tokenizerEnricher, fSemanticProvider, _parser?.Item1);
+
+    public MetadataUpdatableParser(Type metadataUpdateKey, Func<CharParser<TOriginal>> parserFactory, Func<CharParser<TOriginal>, CharParser<TOriginal>> tokenizerEnricher,
+        Func<CharParser<TOriginal>, CharParser<T>> semanticProviderEnricher, CharParser<TOriginal>? originalParser)
+    {
+        _metadataUpdateKey = metadataUpdateKey;
+        _parserFactory = parserFactory;
+        _semanticProviderEnricher = semanticProviderEnricher;
+        _tokenizerEnricher = tokenizerEnricher;
+        if (originalParser is not null)
+        {
+            _parser = Tuple.Create(originalParser, TransformParser(originalParser));
+        }
+#if NET6_0_OR_GREATER
+        MetadataUpdatableManager.Register(metadataUpdateKey, this);
+#endif
+    }
+
+    public override void Run(ref ParserInputReader<char> input, ref ParserCompletionState<T> completionState) =>
+        GetParser().Run(ref input, ref completionState);
+
+    internal override IGrammarProvider GetGrammarProvider() => GetParser().GetGrammarProvider();
+
+    internal override Tokenizer<char> GetTokenizer() => GetParser().GetTokenizer();
+
+    internal override object? GetServiceCore(Type serviceType)
+    {
+        if (serviceType == typeof(IParserStateContextFactory<char, T>))
+        {
+            return this;
+        }
+
+        return GetParser().GetServiceCore(serviceType);
+    }
+
+    private protected override CharParser<TNew> WithSemanticProviderCore<TNew>(ISemanticProvider<char, TNew> semanticProvider) =>
+        WithSemanticProviderEnricher(p => p.WithSemanticProvider(semanticProvider));
+
+    private protected override CharParser<TNew> WithSemanticProviderCore<TNew>(Func<IGrammarProvider, ISemanticProvider<char, TNew>> semanticProviderFactory) =>
+        WithSemanticProviderEnricher(p => p.WithSemanticProvider(semanticProviderFactory));
+
+    private protected override CharParser<T> WithTokenizerCore(Tokenizer<char> tokenizer) =>
+        WithTokenizerEnricher(p => p.WithTokenizer(tokenizer));
+
+    private protected override CharParser<T> WithTokenizerChainCore(ReadOnlySpan<ChainedTokenizerComponent<char>> components)
+    {
+        // Copy span to array to be able to capture it in the closure.
+        var componentsArray = components.ToArray();
+        return WithTokenizerEnricher(p => p.WithTokenizerChain(componentsArray.AsSpan()));
+    }
+
+    public void ClearCache()
+    {
+        _parser = null;
+    }
+
+    ParserStateContext<char, T> IParserStateContextFactory<char, T>.CreateContext(ParserStateContextOptions? options) =>
+        ParserStateContext.Create(GetParser(), options);
+}
+
+internal static class MetadataUpdatableParser
+{
+    public static MetadataUpdatableParser<T, T> Create<T>(Type metadataUpdateKey, Func<CharParser<T>> parserFactory) =>
+        new(metadataUpdateKey, parserFactory, p => p, p => p, parserFactory());
+}

--- a/src/FarkleNeo/Parser/FailingCharParser.cs
+++ b/src/FarkleNeo/Parser/FailingCharParser.cs
@@ -22,9 +22,9 @@ internal sealed class FailingCharParser<T> : CharParser<T>
     public override void Run(ref ParserInputReader<char> input, ref ParserCompletionState<T> completionState) =>
         completionState.SetError(_error);
 
-    private protected override IGrammarProvider GetGrammarProvider() => _grammar;
+    internal override IGrammarProvider GetGrammarProvider() => _grammar;
 
-    private protected override Tokenizer<char> GetTokenizer() => throw new NotSupportedException();
+    internal override Tokenizer<char> GetTokenizer() => throw new NotSupportedException();
 
     private protected override CharParser<TNew> WithSemanticProviderCore<TNew>(ISemanticProvider<char, TNew> semanticProvider) =>
         this as CharParser<TNew> ?? new FailingCharParser<TNew>(_error, _grammar);

--- a/src/FarkleNeo/Parser/Implementation/DefaultParser.cs
+++ b/src/FarkleNeo/Parser/Implementation/DefaultParser.cs
@@ -28,9 +28,9 @@ internal sealed class DefaultParser<T> : CharParser<T>
         _implementation.Run(ref input, ref completionState);
     }
 
-    private protected override IGrammarProvider GetGrammarProvider() => _implementation.Grammar;
+    internal override IGrammarProvider GetGrammarProvider() => _implementation.Grammar;
 
-    private protected override Tokenizer<char> GetTokenizer() => _implementation.Tokenizer;
+    internal override Tokenizer<char> GetTokenizer() => _implementation.Tokenizer;
 
     private protected override CharParser<TNew> WithSemanticProviderCore<TNew>(ISemanticProvider<char, TNew> semanticProvider) =>
         new DefaultParser<TNew>(_implementation.WithSemanticProvider(semanticProvider));

--- a/tests/Farkle.Tests.CSharp/HotReloadTests.cs
+++ b/tests/Farkle.Tests.CSharp/HotReloadTests.cs
@@ -1,0 +1,149 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+#if NET6_0_OR_GREATER
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Runtime.CompilerServices;
+#endif
+using System.Buffers;
+using Farkle.Builder;
+using Farkle.HotReload;
+using Farkle.Parser;
+using Farkle.Parser.Tokenizers;
+
+namespace Farkle.Tests.CSharp;
+
+internal class HotReloadTests
+{
+#if NET6_0_OR_GREATER
+    [Test]
+    public void TestAssemblyAttributes()
+    {
+        var farkleAssembly = typeof(CharParser).Assembly;
+        Assert.That(farkleAssembly.GetCustomAttributes<MetadataUpdateHandlerAttribute>(),
+            Has.One.Matches((MetadataUpdateHandlerAttribute attr) => attr.HandlerType == typeof(MetadataUpdatableManager)));
+    }
+
+    [Test]
+    public void TestMetadataUpdatableManager()
+    {
+        int clearCacheCount1 = 0, clearCacheCount2 = 0;
+        var mdUpdatable1 = new MetadataUpdatable(() => clearCacheCount1++);
+        var mdUpdatable2 = new MetadataUpdatable(() => clearCacheCount2++);
+        MetadataUpdatableManager.Register(typeof(DummyType1), mdUpdatable1);
+        MetadataUpdatableManager.Register(typeof(DummyType2), mdUpdatable2);
+
+        // Clear metadata on only one type.
+        MetadataUpdatableManager.ClearCache([typeof(DummyType1)]);
+        Assert.That((clearCacheCount1, clearCacheCount2), Is.EqualTo((1, 0)));
+        MetadataUpdatableManager.ClearCache([typeof(DummyType2)]);
+        Assert.That((clearCacheCount1, clearCacheCount2), Is.EqualTo((1, 1)));
+        // All types.
+        MetadataUpdatableManager.ClearCache(null);
+        Assert.That((clearCacheCount1, clearCacheCount2), Is.EqualTo((2, 2)));
+        // No types.
+        MetadataUpdatableManager.ClearCache([]);
+        Assert.That((clearCacheCount1, clearCacheCount2), Is.EqualTo((2, 2)));
+        // An irrelevant type.
+        MetadataUpdatableManager.ClearCache([typeof(CharParser)]);
+        Assert.That((clearCacheCount1, clearCacheCount2), Is.EqualTo((2, 2)));
+
+        // The metadata updatable objects might be collected by the GC.
+        GC.KeepAlive(mdUpdatable1);
+        GC.KeepAlive(mdUpdatable2);
+    }
+
+    [Test]
+    public void TestMetadataUpdatableManagerCollectible()
+    {
+        // Create and register a metadata updatable object and check that
+        // it can be collected by the GC.
+        var weakRef = CreateAndRegisterMetadataUpdatable();
+        int gcCollectTries = 10;
+        while (weakRef.IsAlive && gcCollectTries-- > 0)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+        Assert.That(weakRef.IsAlive, Is.False);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static WeakReference CreateAndRegisterMetadataUpdatable()
+        {
+            var mdUpdatable = new MetadataUpdatable(() => { });
+            MetadataUpdatableManager.Register(typeof(DummyType1), mdUpdatable);
+            return new WeakReference(mdUpdatable);
+        }
+    }
+
+    private sealed class MetadataUpdatable(Action fClearCache) : IMetadataUpdatable
+    {
+        public void ClearCache() => fClearCache();
+    }
+
+    private sealed class DummyType1;
+
+    private sealed class DummyType2;
+#endif
+
+    [Test]
+    public void TestMetadataUpdatableParser()
+    {
+        var realParser = Terminal.Literal("aaa").BuildSyntaxCheck();
+        CharParser<object?> mdUpdatableParser = MetadataUpdatableParser.Create(typeof(HotReloadTests), () => realParser);
+
+        // Check clearing the cache without changing the real parser.
+        Assert.That(mdUpdatableParser.GetGrammar(), Is.EqualTo(realParser.GetGrammar()));
+        ClearCache();
+        Assert.That(mdUpdatableParser.GetGrammar(), Is.EqualTo(realParser.GetGrammar()));
+
+        // Check clearing the cache
+        realParser = Terminal.Literal("bbb").BuildSyntaxCheck();
+        ClearCache();
+        Assert.That(mdUpdatableParser.GetGrammar(), Is.EqualTo(realParser.GetGrammar()));
+
+        // Check changing the tokenizer.
+        var newTokenizer = Tokenizer.Create<char>(realParser.GetGrammar());
+        mdUpdatableParser = mdUpdatableParser.WithTokenizer(newTokenizer);
+        Assert.That(mdUpdatableParser.GetTokenizer(), Is.EqualTo(newTokenizer));
+        ClearCache();
+        Assert.That(mdUpdatableParser.GetTokenizer(), Is.EqualTo(newTokenizer));
+
+        void ClearCache() => ((IMetadataUpdatable) mdUpdatableParser).ClearCache();
+    }
+
+    [Test]
+    public void TestParserStateContext()
+    {
+        // Test that Hot Reload does not affect existing parser state contexts.
+        var realParser = Terminal.Literal("aaa").BuildSyntaxCheck();
+        var mdUpdatableParser = MetadataUpdatableParser.Create(typeof(HotReloadTests), () => realParser);
+        var context1 = ParserStateContext.Create(mdUpdatableParser);
+
+        realParser = Terminal.Literal("bbb").BuildSyntaxCheck();
+        mdUpdatableParser.ClearCache();
+        var context2 = ParserStateContext.Create(mdUpdatableParser);
+
+        WriteSpan(context1, "aaa");
+        context1.CompleteInput();
+        WriteSpan(context2, "bbb");
+        context2.CompleteInput();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(context1.Result, TestUtilities.IsParserSuccess);
+            Assert.That(context2.Result, TestUtilities.IsParserSuccess);
+        });
+
+        static void WriteSpan(IBufferWriter<char> bufferWriter, string str)
+        {
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+            bufferWriter.Write(str);
+#else
+            str.AsSpan().CopyTo(bufferWriter.GetSpan(str.Length));
+            bufferWriter.Advance(str.Length);
+#endif
+        }
+    }
+}

--- a/tests/Farkle.Tests.CSharp/TestUtilities.cs
+++ b/tests/Farkle.Tests.CSharp/TestUtilities.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using Farkle.Grammars;
+using NUnit.Framework.Constraints;
 
 namespace Farkle.Tests.CSharp;
 
@@ -21,4 +22,6 @@ public static class TestUtilities
 
     public static Grammar LoadGrammarFromResource(string fileName) =>
         Grammar.CreateFromFile(GetResourceFile(fileName));
+
+    public static ReusableConstraint IsParserSuccess { get; } = Has.Property(nameof(ParserResult<int>.IsSuccess)).True;
 }


### PR DESCRIPTION
This PR adds the following API to create a parser from a parser factory that can be refreshed when performing Hot Reload:

```csharp
namespace Farkle;

public static partial class CharParser
{
    public static CharParser<T> CreateReloadable<T>(Func<T> parserFactory);
}
```

Validated end-to-end manually. It is hard to add an automated end-to-end test, but we test each component of the process individually, which gives sufficient assurances that it works.