### PR TITLE
[release/6.0] Fix off-by-one error when constructing FIRST sets.

### DIFF
--- a/src/Farkle/Builder/LALRBuild.fs
+++ b/src/Farkle/Builder/LALRBuild.fs
@@ -114,7 +114,10 @@ let private computeFirstSetMap (ct: CancellationToken) terminals nonterminals pr
                         dict.AddTerminalsFromNonterminal head nont
                 changed <- changed || changed'
                 i <- i + 1
-            if i = len - 1 && containsEmpty handle.[len - 1] then
+            // If we went through the entire handle and the last member's FIRST set
+            // contains the empty symbol, then the empty symbol is in the FIRST set
+            // of this production's head.
+            if i = len && len > 0 && containsEmpty handle.[len - 1] then
                 changed <- dict.AddEmpty head || changed
 
     dict.Freeze()

--- a/tests/Farkle.Tests/RegressionTests.fs
+++ b/tests/Farkle.Tests/RegressionTests.fs
@@ -7,9 +7,11 @@ module Farkle.Tests.RegressionTests
 
 open Expecto
 open Farkle
+open Farkle.Builder
 open Farkle.Parser
 
 let private reproduceIssue issueNumber = test (sprintf "GitHub issue #%02i" issueNumber)
+let private freproduceIssue issueNumber = ftest (sprintf "GitHub issue #%02i" issueNumber)
 
 let parse rf str = RuntimeFarkle.parseString rf str
 
@@ -26,5 +28,31 @@ let tests = testList "Regression tests" [
 
         Expect.equal (parse rf "3") expectedError
             "The issue was reproduced; parsing a single-digit input was successful, while it shouldn't"
+    }
+    
+    reproduceIssue 301 {
+        let opt_D = "opt_D" |||= [
+            empty
+            !& "d"
+        ]
+
+        let opt_CD = "opt_CD" |||= [
+            !& "c"
+            !% opt_D
+        ]
+
+        let opt_B = "opt_B" |||= [
+            empty
+            !& "b"
+        ]
+
+        let root = "root" |||= [
+            !& "a" .>> opt_B .>> opt_CD .>> "e"
+        ]
+
+        let rf = RuntimeFarkle.buildUntyped root
+        
+        Expect.isOk (parse rf "ae") "Parsing \"ae\" should have succeeded"
+        Expect.isOk (parse rf "abe") "Parsing \"abe\" should have succeeded"
     }
 ]


### PR DESCRIPTION
Fixes #301.

In grammars like `<A> ::= <B>; <B> ::= `, nonterminal `A` mistakenly did not have the empty symbol in its FIRST set due to an off-by-one error. This PR fixes this and adds a regression test provided by the issue's author.