### PR TITLE
Improve the usability of the grammars API et al.

### DIFF
--- a/designs/7.0/grammar-file-format-spec.md
+++ b/designs/7.0/grammar-file-format-spec.md
@@ -161,7 +161,7 @@ The following bit values are defined for the __Flags__ column:
 |Bit|Name|Description|
 |---|----|-----------|
 |0|`Unparsable`|The grammar must not be used for parsing.|
-|1|`Critical`|The grammar must not be used for parsing if it contains data unknown to its reader, as defined later in this specification.|
+|1|`Critical`|The grammar must not be used for parsing if it contains [data unknown to its reader](#unknown-data).|
 
 > Note that the absence of the `Unparsable` flag does not guarantee that the grammar can be parsed. Another way for a grammar to be unparsable is if it lacks a necessary state machine. But if we have say a grammar with a production that has no members, we can emit an unusable state machine for diagnostics purposes, but set the flag.
 
@@ -433,7 +433,9 @@ A GLR(1) state machine has at least one state where there at least one terminal 
 Third parties MAY extend to the grammar file format, through the following mechanisms only:
 
 * Streams whose first byte of the __Identifier__ field is not `0x23`.
+    * Data in custom streams MUST NOT determine the behavior of parsers. Custom streams are intended for peripheral data of informative or diagnostic value.
 * State machines whose __Kind__ is a negative number.
+    * Data in custom state machines MAY determine the behavior of parsers.
 
 Third parties MUST NOT diverge from this specification in any other way (including but not limited to custom tables or flag values).
 
@@ -442,7 +444,6 @@ Third parties MUST NOT diverge from this specification in any other way (includi
 Readers SHOULD expose an API that indicates whether a grammar file contains data unknown to them. Its value MUST be true if the grammar file has one of the following and false otherwise:
 
 * A __MinorVersion__ field that is greater than the latest __MinorVersion__ field the reader knows.
-* A stream whose __Identifier__ field is not known to the reader.
 * A state machine whose __Kind__ is not known to the reader.
 * A table whose kind is not specified in this specification.
 

--- a/src/FarkleNeo/DebuggerTypeProxies.cs
+++ b/src/FarkleNeo/DebuggerTypeProxies.cs
@@ -65,7 +65,6 @@ internal sealed class DfaStateProxy<TChar>
 
         _actions = new NameValuePair[state.Edges.Count + (defaultTransition != -1 ? 1 : 0) + state.AcceptSymbols.Count];
 
-        Grammar grammar = state.Grammar;
         int i = 0;
         foreach (var edge in state.Edges)
         {

--- a/src/FarkleNeo/DebuggerTypeProxies.cs
+++ b/src/FarkleNeo/DebuggerTypeProxies.cs
@@ -16,7 +16,7 @@ internal class FlatCollectionProxy<T, TCollection>(TCollection list) where TColl
 
 internal class DfaProxy<TChar>(Dfa<TChar> dfa) : FlatCollectionProxy<DfaState<TChar>, Dfa<TChar>>(dfa);
 
-internal class DfaAcceptSymbolsProxy<TChar>(DfaState<TChar>.AcceptSymbolCollection collection) : FlatCollectionProxy<TokenSymbolHandle, DfaState<TChar>.AcceptSymbolCollection>(collection);
+internal class DfaAcceptSymbolsProxy<TChar>(DfaState<TChar>.AcceptSymbolCollection collection) : FlatCollectionProxy<TokenSymbol, DfaState<TChar>.AcceptSymbolCollection>(collection);
 
 internal class DfaEdgesProxy<TChar>(DfaState<TChar>.EdgeCollection collection) : FlatCollectionProxy<DfaEdge<TChar>, DfaState<TChar>.EdgeCollection>(collection);
 
@@ -40,8 +40,7 @@ internal sealed class LrStateProxy
         int i = 0;
         foreach (var action in state.Actions)
         {
-            TokenSymbol terminal = grammar.GetTokenSymbol(action.Key);
-            _actions[i++] = new NameValuePair(terminal.ToString(), action.Value.ToString(grammar));
+            _actions[i++] = new NameValuePair(action.Key.ToString(), action.Value.ToString(grammar));
         }
         foreach (var action in state.EndOfFileActions)
         {
@@ -49,8 +48,7 @@ internal sealed class LrStateProxy
         }
         foreach (var @goto in state.Gotos)
         {
-            Nonterminal nonterminal = grammar.GetNonterminal(@goto.Key);
-            _actions[i++] = new NameValuePair(nonterminal.ToString(), $"Goto state {@goto.Value}");
+            _actions[i++] = new NameValuePair(@goto.Key.ToString(), $"Goto state {@goto.Value}");
         }
         Debug.Assert(i == _actions.Length);
     }
@@ -83,7 +81,7 @@ internal sealed class DfaStateProxy<TChar>
         }
         foreach (var accept in state.AcceptSymbols)
         {
-            _actions[i++] = new NameValuePair("Accept", grammar.GetTokenSymbol(accept).ToString());
+            _actions[i++] = new NameValuePair("Accept", accept.ToString());
         }
     }
 }

--- a/src/FarkleNeo/Diagnostics/Builder/LrConflict.cs
+++ b/src/FarkleNeo/Diagnostics/Builder/LrConflict.cs
@@ -134,12 +134,12 @@ public sealed class LrConflict : IFormattable
         {
             foreach (var kvp in state.Actions)
             {
-                if (!firstActionOfTerminal.TryGetValue(kvp.Key, out var firstAction))
+                if (!firstActionOfTerminal.TryGetValue(kvp.Key.Handle, out var firstAction))
                 {
-                    firstActionOfTerminal.Add(kvp.Key, kvp.Value);
+                    firstActionOfTerminal.Add(kvp.Key.Handle, kvp.Value);
                     continue;
                 }
-                yield return Create(states.Grammar, state.StateIndex, kvp.Key, firstAction, kvp.Value);
+                yield return Create(states.Grammar, state.StateIndex, kvp.Key.Handle, firstAction, kvp.Value);
             }
             firstActionOfTerminal.Clear();
 

--- a/src/FarkleNeo/Grammars/Grammar.StringCaching.cs
+++ b/src/FarkleNeo/Grammars/Grammar.StringCaching.cs
@@ -1,0 +1,81 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+namespace Farkle.Grammars;
+
+public partial class Grammar
+{
+    private string?[]? _tokenSymbolNames, _nonterminalNames, _groupNames;
+
+    private string? _grammarName;
+
+    private static ref string? GetTableNameReference(ref string?[]? array, int rowCount, uint tableIndex)
+    {
+        if (Volatile.Read(ref array) is not {} arr)
+        {
+            Interlocked.CompareExchange(ref array, new string[rowCount], null);
+            arr = array;
+        }
+
+        return ref arr[(int)(tableIndex - 1)];
+    }
+
+    internal string GetTokenSymbolName(TokenSymbolHandle handle)
+    {
+        ref string? name = ref GetTableNameReference(ref _tokenSymbolNames, GrammarTables.TokenSymbolRowCount, handle.TableIndex);
+        if (Volatile.Read(ref name) is not {} n)
+        {
+            ReadOnlySpan<byte> grammarFile = GrammarFile;
+            StringHandle nameHandle = GrammarTables.GetTokenSymbolName(grammarFile, handle.TableIndex);
+            string newName = StringHeap.GetString(grammarFile, nameHandle);
+            Interlocked.CompareExchange(ref name, newName, null);
+            n = name;
+        }
+
+        return n;
+    }
+
+    internal string GetNonterminalName(NonterminalHandle handle)
+    {
+        ref string? name = ref GetTableNameReference(ref _nonterminalNames, GrammarTables.NonterminalRowCount, handle.TableIndex);
+        if (Volatile.Read(ref name) is not {} n)
+        {
+            ReadOnlySpan<byte> grammarFile = GrammarFile;
+            StringHandle nameHandle = GrammarTables.GetNonterminalName(grammarFile, handle.TableIndex);
+            string newName = StringHeap.GetString(grammarFile, nameHandle);
+            Interlocked.CompareExchange(ref name, newName, null);
+            n = name;
+        }
+
+        return n;
+    }
+
+    internal string GetGroupName(uint index)
+    {
+        ref string? name = ref GetTableNameReference(ref _groupNames, GrammarTables.GroupRowCount, index);
+        if (Volatile.Read(ref name) is not {} n)
+        {
+            ReadOnlySpan<byte> grammarFile = GrammarFile;
+            StringHandle nameHandle = GrammarTables.GetGroupName(grammarFile, index);
+            string newName = StringHeap.GetString(grammarFile, nameHandle);
+            Interlocked.CompareExchange(ref name, newName, null);
+            n = name;
+        }
+
+        return n;
+    }
+
+    internal string GetGrammarName()
+    {
+        if (Volatile.Read(ref _grammarName) is not {} n)
+        {
+            ReadOnlySpan<byte> grammarFile = GrammarFile;
+            StringHandle nameHandle = GrammarTables.GetGrammarName(grammarFile);
+            string newName = StringHeap.GetString(grammarFile, nameHandle);
+            Interlocked.CompareExchange(ref _grammarName, newName, null);
+            n = _grammarName;
+        }
+
+        return n;
+    }
+}

--- a/src/FarkleNeo/Grammars/Grammar.cs
+++ b/src/FarkleNeo/Grammars/Grammar.cs
@@ -17,7 +17,7 @@ namespace Farkle.Grammars;
 /// The grammar's data is internally stored in a binary format described in
 /// <see href="https://github.com/teo-tsirpanis/Farkle/blob/mainstream/designs/7.0/grammar-file-format-spec.md"/>
 /// </remarks>
-public abstract class Grammar : IGrammarProvider
+public abstract partial class Grammar : IGrammarProvider
 {
     internal readonly StringHeap StringHeap;
     internal readonly BlobHeap BlobHeap;
@@ -231,12 +231,6 @@ public abstract class Grammar : IGrammarProvider
         }
         throw new NotSupportedException();
     }
-
-    /// <summary>
-    /// Returns the string pointed by the given <see cref="StringHandle"/>.
-    /// </summary>
-    /// <param name="handle">The string handle to retrieve the string from.</param>
-    public string GetString(StringHandle handle) => StringHeap.GetString(GrammarFile, handle);
 
     /// <summary>
     /// Gets the <see cref="TokenSymbol"/> pointed by the given <see cref="TokenSymbolHandle"/>.

--- a/src/FarkleNeo/Grammars/Grammar.cs
+++ b/src/FarkleNeo/Grammars/Grammar.cs
@@ -99,7 +99,7 @@ public abstract partial class Grammar : IGrammarProvider
         GrammarHeader header = GrammarHeader.Read(grammarFile);
         ValidateHeader(header);
 
-        GrammarStreams streams = new(grammarFile, header.StreamCount, out bool hasUnknownStreams);
+        GrammarStreams streams = new(grammarFile, header.StreamCount);
 
         StringHeap = new(grammarFile, streams.StringHeap);
         BlobHeap = new(streams.BlobHeap);
@@ -108,7 +108,7 @@ public abstract partial class Grammar : IGrammarProvider
         GrammarStateMachines stateMachines = new(grammarFile, in BlobHeap, in GrammarTables, out bool hasUnknownStateMachines);
         (DfaOnChar, LrStateMachine) = StateMachineUtilities.GetGrammarStateMachines(this, grammarFile, in stateMachines);
 
-        HasUnknownData = header.HasUnknownData || hasUnknownStreams || hasUnknownTables || hasUnknownStateMachines;
+        HasUnknownData = header.HasUnknownData || hasUnknownTables || hasUnknownStateMachines;
     }
 
     /// <summary>

--- a/src/FarkleNeo/Grammars/GrammarInfo.cs
+++ b/src/FarkleNeo/Grammars/GrammarInfo.cs
@@ -32,7 +32,7 @@ public readonly struct GrammarInfo
     /// <summary>
     /// The grammar's starting nonterminal.
     /// </summary>
-    public NonterminalHandle StartSymbol => _grammar.GrammarTables.GetGrammarStartSymbol(_grammar.GrammarFile);
+    public Nonterminal StartSymbol => new(_grammar, _grammar.GrammarTables.GetGrammarStartSymbol(_grammar.GrammarFile));
 
     /// <summary>
     /// The grammar's <see cref="GrammarAttributes"/>.

--- a/src/FarkleNeo/Grammars/GrammarInfo.cs
+++ b/src/FarkleNeo/Grammars/GrammarInfo.cs
@@ -22,12 +22,7 @@ public readonly struct GrammarInfo
     /// <summary>
     /// The grammar's name.
     /// </summary>
-    public string Name => _grammar.GetString(NameHandle);
-
-    /// <summary>
-    /// A <see cref="StringHandle"/> pointing to the grammar's name.
-    /// </summary>
-    public StringHandle NameHandle => _grammar.GrammarTables.GetGrammarName(_grammar.GrammarFile);
+    public string Name => _grammar.GetGrammarName();
 
     /// <summary>
     /// The grammar's starting nonterminal.

--- a/src/FarkleNeo/Grammars/GrammarInfo.cs
+++ b/src/FarkleNeo/Grammars/GrammarInfo.cs
@@ -20,9 +20,14 @@ public readonly struct GrammarInfo
     }
 
     /// <summary>
+    /// The grammar's name.
+    /// </summary>
+    public string Name => _grammar.GetString(NameHandle);
+
+    /// <summary>
     /// A <see cref="StringHandle"/> pointing to the grammar's name.
     /// </summary>
-    public StringHandle Name => _grammar.GrammarTables.GetGrammarName(_grammar.GrammarFile);
+    public StringHandle NameHandle => _grammar.GrammarTables.GetGrammarName(_grammar.GrammarFile);
 
     /// <summary>
     /// The grammar's starting nonterminal.

--- a/src/FarkleNeo/Grammars/GrammarStreams.cs
+++ b/src/FarkleNeo/Grammars/GrammarStreams.cs
@@ -27,10 +27,9 @@ internal readonly struct GrammarStreams
         // Length
         + sizeof(int);
 
-    public GrammarStreams(ReadOnlySpan<byte> grammarFile, uint streamCount, out bool hasUnknownStreams)
+    public GrammarStreams(ReadOnlySpan<byte> grammarFile, uint streamCount)
     {
         bool seenStringHeap = false, seenBlobHeap = false, seenTableStream = false;
-        hasUnknownStreams = false;
 
         if ((uint)grammarFile.Length < StreamDefinitionsOffset + streamCount * StreamDefinitionSize)
         {
@@ -61,7 +60,6 @@ internal readonly struct GrammarStreams
                 default:
                     // We could have detected duplicate unknown streams to fully conform with the spec,
                     // but let's not, we don't care about them. We do however check their bounds.
-                    hasUnknownStreams = true;
                     break;
             }
         }

--- a/src/FarkleNeo/Grammars/GrammarTablesHotData.cs
+++ b/src/FarkleNeo/Grammars/GrammarTablesHotData.cs
@@ -56,14 +56,6 @@ internal readonly ref struct GrammarTablesHotData
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public StringHandle GetGroupName(uint group)
-    {
-        Debug.Assert(group != 0 && group <= (uint)GrammarTables.GroupRowCount);
-
-        return GrammarTables.GetGroupName(GrammarFile, group);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public TokenSymbolHandle GetGroupContainer(uint group)
     {
         Debug.Assert(group != 0 && group <= (uint)GrammarTables.GroupRowCount);

--- a/src/FarkleNeo/Grammars/Group.cs
+++ b/src/FarkleNeo/Grammars/Group.cs
@@ -37,9 +37,14 @@ public readonly struct Group
     }
 
     /// <summary>
+    /// The <see cref="Group"/>'s name.
+    /// </summary>
+    public string Name => _grammar.GetString(NameHandle);
+
+    /// <summary>
     /// A <see cref="StringHandle"/> pointing to the <see cref="Group"/>'s name.
     /// </summary>
-    public StringHandle Name
+    public StringHandle NameHandle
     {
         get
         {
@@ -112,5 +117,5 @@ public readonly struct Group
     /// <summary>
     /// Returns a string describing the the <see cref="Group"/>.
     /// </summary>
-    public override string ToString() => _grammar.GetString(Name);
+    public override string ToString() => _grammar is null ? "" : Name;
 }

--- a/src/FarkleNeo/Grammars/Group.cs
+++ b/src/FarkleNeo/Grammars/Group.cs
@@ -39,17 +39,12 @@ public readonly struct Group
     /// <summary>
     /// The <see cref="Group"/>'s name.
     /// </summary>
-    public string Name => _grammar.GetString(NameHandle);
-
-    /// <summary>
-    /// A <see cref="StringHandle"/> pointing to the <see cref="Group"/>'s name.
-    /// </summary>
-    public StringHandle NameHandle
+    public string Name
     {
         get
         {
             AssertHasValue();
-            return _grammar.GrammarTables.GetGroupName(_grammar.GrammarFile, Index);
+            return _grammar.GetGroupName(Index);
         }
     }
 

--- a/src/FarkleNeo/Grammars/Group.cs
+++ b/src/FarkleNeo/Grammars/Group.cs
@@ -54,14 +54,14 @@ public readonly struct Group
     }
 
     /// <summary>
-    /// A <see cref="TokenSymbolHandle"/> pointing to the token symbol that represents the <see cref="Group"/>'s content.
+    /// The token symbol that represents the <see cref="Group"/>'s content.
     /// </summary>
-    public TokenSymbolHandle Container
+    public TokenSymbol Container
     {
         get
         {
             AssertHasValue();
-            return _grammar.GrammarTables.GetGroupContainer(_grammar.GrammarFile, Index);
+            return new(_grammar, _grammar.GrammarTables.GetGroupContainer(_grammar.GrammarFile, Index));
         }
     }
 
@@ -78,26 +78,26 @@ public readonly struct Group
     }
 
     /// <summary>
-    /// A <see cref="TokenSymbolHandle"/> pointing to the token symbol that starts this <see cref="Group"/>.
+    /// The token symbol that starts this <see cref="Group"/>.
     /// </summary>
-    public TokenSymbolHandle Start
+    public TokenSymbol Start
     {
         get
         {
             AssertHasValue();
-            return _grammar.GrammarTables.GetGroupStart(_grammar.GrammarFile, Index);
+            return new(_grammar, _grammar.GrammarTables.GetGroupStart(_grammar.GrammarFile, Index));
         }
     }
 
     /// <summary>
-    /// A <see cref="TokenSymbolHandle"/> pointing to the token symbol that ends this <see cref="Group"/>.
+    /// The token symbol that ends this <see cref="Group"/>.
     /// </summary>
-    public TokenSymbolHandle End
+    public TokenSymbol End
     {
         get
         {
             AssertHasValue();
-            return _grammar.GrammarTables.GetGroupEnd(_grammar.GrammarFile, Index);
+            return new(_grammar, _grammar.GrammarTables.GetGroupEnd(_grammar.GrammarFile, Index));
         }
     }
 

--- a/src/FarkleNeo/Grammars/Nonterminal.cs
+++ b/src/FarkleNeo/Grammars/Nonterminal.cs
@@ -39,9 +39,14 @@ public readonly struct Nonterminal
     }
 
     /// <summary>
+    /// The <see cref="Nonterminal"/>'s name.
+    /// </summary>
+    public string Name => _grammar.GetString(NameHandle);
+
+    /// <summary>
     /// A <see cref="StringHandle"/> pointing to the <see cref="Nonterminal"/>'s name.
     /// </summary>
-    public StringHandle Name
+    public StringHandle NameHandle
     {
         get
         {
@@ -78,5 +83,5 @@ public readonly struct Nonterminal
     /// <summary>
     /// Returns a string describing the the <see cref="Nonterminal"/>.
     /// </summary>
-    public override string ToString() => $"<{_grammar.GetString(Name)}>";
+    public override string ToString() => _grammar is null ? "" : $"<{Name}>";
 }

--- a/src/FarkleNeo/Grammars/Nonterminal.cs
+++ b/src/FarkleNeo/Grammars/Nonterminal.cs
@@ -41,17 +41,12 @@ public readonly struct Nonterminal
     /// <summary>
     /// The <see cref="Nonterminal"/>'s name.
     /// </summary>
-    public string Name => _grammar.GetString(NameHandle);
-
-    /// <summary>
-    /// A <see cref="StringHandle"/> pointing to the <see cref="Nonterminal"/>'s name.
-    /// </summary>
-    public StringHandle NameHandle
+    public string Name
     {
         get
         {
             AssertHasValue();
-            return _grammar.GrammarTables.GetNonterminalName(_grammar.GrammarFile, Handle.TableIndex);
+            return _grammar.GetNonterminalName(Handle);
         }
     }
 

--- a/src/FarkleNeo/Grammars/Production.cs
+++ b/src/FarkleNeo/Grammars/Production.cs
@@ -43,14 +43,14 @@ public readonly struct Production
     }
 
     /// <summary>
-    /// A <see cref="NonterminalHandle"/> pointing to the <see cref="Production"/>'s head.
+    /// The <see cref="Production"/>'s head.
     /// </summary>
-    public NonterminalHandle Head
+    public Nonterminal Head
     {
         get
         {
             AssertHasValue();
-            return _grammar.GrammarTables.GetProductionHead(_grammar.GrammarFile, Handle.TableIndex);
+            return new(_grammar, _grammar.GrammarTables.GetProductionHead(_grammar.GrammarFile, Handle.TableIndex));
         }
     }
 
@@ -74,7 +74,7 @@ public readonly struct Production
     {
         StringBuilder sb = new();
 
-        sb.Append(_grammar.GetNonterminal(Head));
+        sb.Append(Head);
         sb.Append(" ::=");
         foreach (EntityHandle member in Members)
         {

--- a/src/FarkleNeo/Grammars/StateMachines/Dfa.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/Dfa.cs
@@ -22,14 +22,15 @@ namespace Farkle.Grammars.StateMachines;
 [DebuggerTypeProxy(typeof(DfaProxy<>))]
 public abstract class Dfa<TChar> : IReadOnlyList<DfaState<TChar>>
 {
-    internal Dfa(int stateCount, bool hasConflicts)
+    internal Dfa(Grammar grammar, int stateCount, bool hasConflicts)
     {
         Debug.Assert(stateCount > 0);
+        Grammar = grammar;
         Count = stateCount;
         HasConflicts = hasConflicts;
     }
 
-    internal abstract Grammar Grammar { get; }
+    internal Grammar Grammar { get; }
 
     internal abstract (int Offset, int Count) GetAcceptSymbolBounds(int state);
 

--- a/src/FarkleNeo/Grammars/StateMachines/DfaImplementationBase.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/DfaImplementationBase.cs
@@ -25,13 +25,12 @@ internal unsafe abstract class DfaImplementationBase<TChar> : Dfa<TChar> where T
 
     public required int AcceptBase { get; init; }
 
-    protected DfaImplementationBase(Grammar grammar, int stateCount, int edgeCount, int tokenSymbolCount, bool hasConflicts) : base(stateCount, hasConflicts)
+    protected DfaImplementationBase(Grammar grammar, int stateCount, int edgeCount, int tokenSymbolCount, bool hasConflicts) : base(grammar, stateCount, hasConflicts)
     {
         _stateIndexSize = GrammarUtilities.GetCompressedIndexSize(stateCount);
         _edgeIndexSize = GrammarUtilities.GetCompressedIndexSize(edgeCount);
         _tokenSymbolIndexSize = GrammarUtilities.GetCompressedIndexSize(tokenSymbolCount);
 
-        Grammar = grammar;
         _edgeCount = edgeCount;
     }
 
@@ -43,8 +42,6 @@ internal unsafe abstract class DfaImplementationBase<TChar> : Dfa<TChar> where T
 
     protected TokenSymbolHandle ReadAcceptSymbol(ReadOnlySpan<byte> grammarFile, int index) =>
         new(grammarFile.ReadUIntVariableSize(AcceptBase + index * _tokenSymbolIndexSize, _tokenSymbolIndexSize));
-
-    internal sealed override Grammar Grammar { get; }
 
     private int GetDefaultTransitionUnsafe(ReadOnlySpan<byte> grammarFile, int state)
     {

--- a/src/FarkleNeo/Grammars/StateMachines/DfaState.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/DfaState.cs
@@ -178,7 +178,7 @@ public readonly struct DfaState<TChar>
     /// Contains the accept symbols of a <see cref="DfaState{TChar}"/>.
     /// </summary>
     [DebuggerTypeProxy(typeof(DfaAcceptSymbolsProxy<>))]
-    public readonly struct AcceptSymbolCollection : IReadOnlyCollection<TokenSymbolHandle>
+    public readonly struct AcceptSymbolCollection : IReadOnlyCollection<TokenSymbol>
     {
         private readonly Dfa<TChar> _dfa;
 
@@ -199,14 +199,14 @@ public readonly struct DfaState<TChar>
         /// </summary>
         public Enumerator GetEnumerator() => new(this);
 
-        IEnumerator<TokenSymbolHandle> IEnumerable<TokenSymbolHandle>.GetEnumerator() => GetEnumerator();
+        IEnumerator<TokenSymbol> IEnumerable<TokenSymbol>.GetEnumerator() => GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <summary>
         /// Used to enumerate an <see cref="AcceptSymbolCollection"/>.
         /// </summary>
-        public struct Enumerator : IEnumerator<TokenSymbolHandle>
+        public struct Enumerator : IEnumerator<TokenSymbol>
         {
             private readonly AcceptSymbolCollection _collection;
 
@@ -218,7 +218,7 @@ public readonly struct DfaState<TChar>
             }
 
             /// <inheritdoc/>
-            public TokenSymbolHandle Current
+            public TokenSymbol Current
             {
                 get
                 {
@@ -226,7 +226,7 @@ public readonly struct DfaState<TChar>
                     {
                         ThrowHelpers.ThrowInvalidOperationException();
                     }
-                    return _collection._dfa.GetAcceptSymbolAt(_collection._offset + _currentIndex);
+                    return new(_collection._dfa.Grammar, _collection._dfa.GetAcceptSymbolAt(_collection._offset + _currentIndex));
                 }
             }
 

--- a/src/FarkleNeo/Grammars/StateMachines/LrImplementationBase.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrImplementationBase.cs
@@ -32,7 +32,7 @@ internal unsafe abstract class LrImplementationBase : LrStateMachine
 
     public required int GotoStateBase { get; init; }
 
-    protected LrImplementationBase(Grammar grammar, int stateCount, int actionCount, int gotoCount, in GrammarTables grammarTables, bool hasConflicts) : base(stateCount, hasConflicts)
+    protected LrImplementationBase(Grammar grammar, int stateCount, int actionCount, int gotoCount, in GrammarTables grammarTables, bool hasConflicts) : base(grammar, stateCount, hasConflicts)
     {
         _stateIndexSize = GrammarUtilities.GetCompressedIndexSize(stateCount);
         _actionIndexSize = GrammarUtilities.GetCompressedIndexSize(actionCount);
@@ -42,7 +42,6 @@ internal unsafe abstract class LrImplementationBase : LrStateMachine
         _tokenSymbolIndexSize = GrammarUtilities.GetCompressedIndexSize(grammarTables.TokenSymbolRowCount);
         _nonterminalIndexSize = GrammarUtilities.GetCompressedIndexSize(grammarTables.NonterminalRowCount);
 
-        Grammar = grammar;
         ActionCount = actionCount;
         GotoCount = gotoCount;
     }
@@ -64,8 +63,6 @@ internal unsafe abstract class LrImplementationBase : LrStateMachine
 
     protected static uint ReadUIntVariableSizeFromArray(ReadOnlySpan<byte> grammarFile, int @base, int index, byte indexSize) =>
         grammarFile.ReadUIntVariableSize(@base + index * indexSize, indexSize);
-
-    internal sealed override Grammar Grammar { get; }
 
     internal override void PrepareForParsing()
     {

--- a/src/FarkleNeo/Grammars/StateMachines/LrState.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrState.cs
@@ -57,8 +57,8 @@ public readonly struct LrState
     /// Contains the terminals an <see cref="LrState"/> accepts,
     /// along with their respective <see cref="LrAction"/>.
     /// </summary>
-    [DebuggerTypeProxy(typeof(FlatCollectionProxy<KeyValuePair<TokenSymbolHandle, LrAction>, ActionCollection>))]
-    public readonly struct ActionCollection : IReadOnlyCollection<KeyValuePair<TokenSymbolHandle, LrAction>>
+    [DebuggerTypeProxy(typeof(FlatCollectionProxy<KeyValuePair<TokenSymbol, LrAction>, ActionCollection>))]
+    public readonly struct ActionCollection : IReadOnlyCollection<KeyValuePair<TokenSymbol, LrAction>>
     {
         private readonly LrStateMachine _lr;
 
@@ -78,15 +78,15 @@ public readonly struct LrState
         /// </summary>
         public Enumerator GetEnumerator() => new(this);
 
-        IEnumerator<KeyValuePair<TokenSymbolHandle, LrAction>>
-            IEnumerable<KeyValuePair<TokenSymbolHandle, LrAction>>.GetEnumerator() => GetEnumerator();
+        IEnumerator<KeyValuePair<TokenSymbol, LrAction>>
+            IEnumerable<KeyValuePair<TokenSymbol, LrAction>>.GetEnumerator() => GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <summary>
         /// Used to enumerate an <see cref="ActionCollection"/>.
         /// </summary>
-        public struct Enumerator : IEnumerator<KeyValuePair<TokenSymbolHandle, LrAction>>
+        public struct Enumerator : IEnumerator<KeyValuePair<TokenSymbol, LrAction>>
         {
             private readonly ActionCollection _collection;
 
@@ -98,7 +98,7 @@ public readonly struct LrState
             }
 
             /// <inheritdoc/>
-            public KeyValuePair<TokenSymbolHandle, LrAction> Current
+            public KeyValuePair<TokenSymbol, LrAction> Current
             {
                 get
                 {
@@ -106,7 +106,8 @@ public readonly struct LrState
                     {
                         ThrowHelpers.ThrowInvalidOperationException();
                     }
-                    return _collection._lr.GetActionAt(_collection._offset + _currentIndex);
+                    var action = _collection._lr.GetActionAt(_collection._offset + _currentIndex);
+                    return new(new(_collection._lr.Grammar, action.Key), action.Value);
                 }
             }
 
@@ -208,8 +209,8 @@ public readonly struct LrState
     /// <summary>
     /// Contains pairs of <see cref="NonterminalHandle"/>s and their respective GOTO destination states.
     /// </summary>
-    [DebuggerTypeProxy(typeof(FlatCollectionProxy<KeyValuePair<NonterminalHandle, int>, GotoCollection>))]
-    public readonly struct GotoCollection : IReadOnlyCollection<KeyValuePair<NonterminalHandle, int>>
+    [DebuggerTypeProxy(typeof(FlatCollectionProxy<KeyValuePair<Nonterminal, int>, GotoCollection>))]
+    public readonly struct GotoCollection : IReadOnlyCollection<KeyValuePair<Nonterminal, int>>
     {
         private readonly LrStateMachine _lr;
 
@@ -229,15 +230,15 @@ public readonly struct LrState
         /// </summary>
         public Enumerator GetEnumerator() => new(this);
 
-        IEnumerator<KeyValuePair<NonterminalHandle, int>>
-            IEnumerable<KeyValuePair<NonterminalHandle, int>>.GetEnumerator() => GetEnumerator();
+        IEnumerator<KeyValuePair<Nonterminal, int>>
+            IEnumerable<KeyValuePair<Nonterminal, int>>.GetEnumerator() => GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <summary>
         /// Used to enumerate a <see cref="GotoCollection"/>.
         /// </summary>
-        public struct Enumerator : IEnumerator<KeyValuePair<NonterminalHandle, int>>
+        public struct Enumerator : IEnumerator<KeyValuePair<Nonterminal, int>>
         {
             private readonly GotoCollection _collection;
 
@@ -249,7 +250,7 @@ public readonly struct LrState
             }
 
             /// <inheritdoc/>
-            public KeyValuePair<NonterminalHandle, int> Current
+            public KeyValuePair<Nonterminal, int> Current
             {
                 get
                 {
@@ -257,7 +258,8 @@ public readonly struct LrState
                     {
                         ThrowHelpers.ThrowInvalidOperationException();
                     }
-                    return _collection._lr.GetGotoAt(_collection._offset + _currentIndex);
+                    var @goto = _collection._lr.GetGotoAt(_collection._offset + _currentIndex);
+                    return new(new(_collection._lr.Grammar, @goto.Key), @goto.Value);
                 }
             }
 

--- a/src/FarkleNeo/Grammars/StateMachines/LrStateMachine.cs
+++ b/src/FarkleNeo/Grammars/StateMachines/LrStateMachine.cs
@@ -14,14 +14,15 @@ namespace Farkle.Grammars.StateMachines;
 [DebuggerTypeProxy(typeof(FlatCollectionProxy<LrState, LrStateMachine>))]
 public abstract class LrStateMachine : IReadOnlyList<LrState>
 {
-    internal LrStateMachine(int count, bool hasConflicts)
+    internal LrStateMachine(Grammar grammar, int count, bool hasConflicts)
     {
         Debug.Assert(count > 0);
+        Grammar = grammar;
         Count = count;
         HasConflicts = hasConflicts;
     }
 
-    internal abstract Grammar Grammar { get; }
+    internal Grammar Grammar { get; }
 
     internal abstract (int Offset, int Count) GetActionBounds(int state);
 

--- a/src/FarkleNeo/Grammars/StringHandle.cs
+++ b/src/FarkleNeo/Grammars/StringHandle.cs
@@ -6,8 +6,7 @@ namespace Farkle.Grammars;
 /// <summary>
 /// Points to a string in a <see cref="Grammar"/>.
 /// </summary>
-/// <seealso cref="Grammar.GetString"/>
-public readonly struct StringHandle : IEquatable<StringHandle>
+internal readonly struct StringHandle : IEquatable<StringHandle>
 {
     internal uint Value { get; }
 

--- a/src/FarkleNeo/Grammars/TokenSymbol.cs
+++ b/src/FarkleNeo/Grammars/TokenSymbol.cs
@@ -29,9 +29,14 @@ public readonly struct TokenSymbol
     }
 
     /// <summary>
+    /// The <see cref="TokenSymbol"/>'s name.
+    /// </summary>
+    public string Name => _grammar.GetString(NameHandle);
+
+    /// <summary>
     /// A <see cref="StringHandle"/> pointing to the <see cref="TokenSymbol"/>'s name.
     /// </summary>
-    public StringHandle Name
+    public StringHandle NameHandle
     {
         get
         {
@@ -83,5 +88,5 @@ public readonly struct TokenSymbol
     /// <summary>
     /// Returns a string describing the the <see cref="TokenSymbol"/>.
     /// </summary>
-    public override string ToString() => FormatName(_grammar.GetString(Name));
+    public override string ToString() => _grammar is null ? "" : FormatName(Name);
 }

--- a/src/FarkleNeo/Grammars/TokenSymbol.cs
+++ b/src/FarkleNeo/Grammars/TokenSymbol.cs
@@ -31,12 +31,7 @@ public readonly struct TokenSymbol
     /// <summary>
     /// The <see cref="TokenSymbol"/>'s name.
     /// </summary>
-    public string Name => _grammar.GetString(NameHandle);
-
-    /// <summary>
-    /// A <see cref="StringHandle"/> pointing to the <see cref="TokenSymbol"/>'s name.
-    /// </summary>
-    public StringHandle NameHandle
+    public string Name
     {
         get
         {
@@ -44,7 +39,7 @@ public readonly struct TokenSymbol
             {
                 ThrowHelpers.ThrowHandleHasNoValue();
             }
-            return _grammar.GrammarTables.GetTokenSymbolName(_grammar.GrammarFile, Handle.TableIndex);
+            return _grammar.GetTokenSymbolName(Handle);
         }
     }
 

--- a/src/FarkleNeo/Parser/Implementation/DefaultParserImplementation.cs
+++ b/src/FarkleNeo/Parser/Implementation/DefaultParserImplementation.cs
@@ -136,7 +136,7 @@ internal readonly struct DefaultParserImplementation<TChar>
                 }
             }
             TextPosition errorPos = foundToken ? token.Position : input.State.CurrentPosition;
-            string? actualTokenName = foundToken ? Grammar.GetString(Grammar.GetTokenSymbol(token.Symbol).Name) : null;
+            string? actualTokenName = foundToken ? Grammar.GetTokenSymbol(token.Symbol).Name : null;
             ImmutableArray<string?> expectedTokens = ParserUtilities.GetExpectedSymbols(Grammar, _lrStateMachine[currentState]);
             result = new ParserDiagnostic(errorPos, new SyntaxError(actualTokenName, expectedTokens, currentState));
             return RunResult.Failure;

--- a/src/FarkleNeo/Parser/Implementation/DefaultParserImplementation.cs
+++ b/src/FarkleNeo/Parser/Implementation/DefaultParserImplementation.cs
@@ -18,7 +18,7 @@ namespace Farkle.Parser.Implementation;
 internal readonly struct DefaultParserImplementation<TChar>
 {
     public Grammar Grammar { get; }
-    private readonly LrStateMachine _lrStateMachine;
+    private readonly LrWithoutConflicts _lrStateMachine;
     private readonly object _semanticProvider;
     public Tokenizer<TChar> Tokenizer { get; }
 
@@ -29,8 +29,9 @@ internal readonly struct DefaultParserImplementation<TChar>
 
     private DefaultParserImplementation(Grammar grammar, LrStateMachine lrStateMachine, object semanticProvider, Tokenizer<TChar> tokenizer)
     {
+        Debug.Assert(!lrStateMachine.HasConflicts);
         Grammar = grammar;
-        _lrStateMachine = lrStateMachine;
+        _lrStateMachine = (LrWithoutConflicts)lrStateMachine;
         _lrStateMachine.PrepareForParsing();
         _semanticProvider = semanticProvider;
         Tokenizer = tokenizer;

--- a/src/FarkleNeo/Parser/Implementation/DefaultTokenizer.cs
+++ b/src/FarkleNeo/Parser/Implementation/DefaultTokenizer.cs
@@ -11,16 +11,16 @@ using System.Diagnostics;
 
 namespace Farkle.Parser.Implementation;
 
-internal sealed class DefaultTokenizer<TChar> : Tokenizer<TChar>, ITokenizerResumptionPoint<TChar, DefaultTokenizer<TChar>.GroupState>
+internal sealed class DefaultTokenizer<TChar> : Tokenizer<TChar>, ITokenizerResumptionPoint<TChar, DefaultTokenizer<TChar>.GroupState> where TChar : unmanaged, IComparable<TChar>
 {
     private readonly Grammar _grammar;
-    private readonly Dfa<TChar> _dfa;
+    private readonly DfaWithoutConflicts<TChar> _dfa;
 
     public DefaultTokenizer(Grammar grammar, Dfa<TChar> dfa)
     {
         Debug.Assert(!dfa.HasConflicts);
         _grammar = grammar;
-        _dfa = dfa;
+        _dfa = (DfaWithoutConflicts<TChar>)dfa;
         _dfa.PrepareForParsing();
         // If a grammar does not have any groups, we will suspend only to return
         // to the main tokenizer entry point. Without a wrapping, it would be called

--- a/src/FarkleNeo/Parser/Implementation/DefaultTokenizer.cs
+++ b/src/FarkleNeo/Parser/Implementation/DefaultTokenizer.cs
@@ -67,7 +67,7 @@ internal sealed class DefaultTokenizer<TChar> : Tokenizer<TChar>, ITokenizerResu
                     // Consume all remaining characters to get the position at the end of input.
                     // If we are in a noise group, they are already consumed and this will do nothing.
                     input.Consume(input.RemainingCharacters.Length);
-                    string groupName = _grammar.GetString(hotData.GetGroupName(currentGroup));
+                    string groupName = _grammar.GetGroupName(currentGroup);
                     error = new(input.State.CurrentPosition, new UnexpectedEndOfInputInGroupError(groupName));
                     return true;
                 }

--- a/src/FarkleNeo/Parser/Implementation/ParserUtilities.cs
+++ b/src/FarkleNeo/Parser/Implementation/ParserUtilities.cs
@@ -56,7 +56,7 @@ internal static class ParserUtilities
             {
                 continue;
             }
-            builder.Add(grammar.GetString(symbol.Name));
+            builder.Add(symbol.Name);
         }
         if (state.EndOfFileActions.Count > 0)
         {

--- a/src/FarkleNeo/Parser/Implementation/ParserUtilities.cs
+++ b/src/FarkleNeo/Parser/Implementation/ParserUtilities.cs
@@ -50,7 +50,7 @@ internal static class ParserUtilities
         var builder = ImmutableArray.CreateBuilder<string?>();
         foreach (var action in state.Actions)
         {
-            TokenSymbol symbol = grammar.GetTokenSymbol(action.Key);
+            TokenSymbol symbol = action.Key;
             // TODO: Add a test once we add the builder and can define hidden terminals.
             if ((symbol.Attributes & TokenSymbolAttributes.Hidden) != 0)
             {

--- a/src/FarkleNeo/Parser/Tokenizers/Tokenizer.cs
+++ b/src/FarkleNeo/Parser/Tokenizers/Tokenizer.cs
@@ -92,7 +92,8 @@ public static class Tokenizer
     /// <exception cref="ArgumentNullException"><paramref name="grammar"/> is <see langword="null"/>.</exception>
     /// <exception cref="NotSupportedException"><typeparamref name="TChar"/> is not <see cref="char"/>.</exception>
     /// <exception cref="InvalidOperationException">The grammar cannot be used for tokenizing.</exception>
-    public static Tokenizer<TChar> Create<TChar>(Grammar grammar) => Create<TChar>(grammar, throwIfError: true);
+    public static Tokenizer<TChar> Create<TChar>(Grammar grammar) where TChar : unmanaged, IComparable<TChar> =>
+        Create<TChar>(grammar, throwIfError: true);
 
     /// <summary>
     /// Creates a <see cref="Tokenizer{TChar}"/> from a tokenizer chain.
@@ -148,6 +149,7 @@ public static class Tokenizer
     }
 
     internal static Tokenizer<TChar> Create<TChar>(Grammar grammar, bool throwIfError, object? customError = null)
+        where TChar : unmanaged, IComparable<TChar>
     {
         ArgumentNullExceptionCompat.ThrowIfNull(grammar);
         if (grammar.IsUnparsable(out string? errorKey))

--- a/tests/Farkle.Tests.CSharp/GrammarTests.cs
+++ b/tests/Farkle.Tests.CSharp/GrammarTests.cs
@@ -73,35 +73,35 @@ internal class GrammarTests
         Assert.Multiple(() =>
         {
             Assert.That(grammar.HasUnknownData, Is.False);
-            Assert.That(grammar.GrammarInfo.Name.IsEmpty, Is.False);
+            Assert.That(grammar.GrammarInfo.Name, Is.Not.Empty);
             Assert.That(() => grammar.GrammarInfo.Attributes, Throws.Nothing);
-            Assert.That(grammar.GrammarInfo.StartSymbol.HasValue);
+            Assert.That(grammar.GrammarInfo.StartSymbol.Handle.HasValue);
 
             foreach (var tokenSymbol in grammar.TokenSymbols)
             {
-                Assert.That(tokenSymbol.Name.IsEmpty, Is.False);
+                Assert.That(tokenSymbol.Name, Is.Not.Empty);
                 Assert.That(() => tokenSymbol.Attributes, Throws.Nothing);
             }
 
             foreach (var nonterminal in grammar.Nonterminals)
             {
-                Assert.That(nonterminal.Name.IsEmpty, Is.False);
+                Assert.That(nonterminal.Name, Is.Not.Empty);
                 Assert.That(() => nonterminal.Attributes, Throws.Nothing);
             }
 
             foreach (var group in grammar.Groups)
             {
-                Assert.That(group.Name.IsEmpty, Is.False);
-                Assert.That(group.Container.HasValue);
+                Assert.That(group.Name, Is.Not.Empty);
+                Assert.That(group.Container.Handle.HasValue);
                 Assert.That(() => group.Attributes, Throws.Nothing);
-                Assert.That(group.Start.HasValue);
-                Assert.That(group.End.HasValue);
+                Assert.That(group.Start.Handle.HasValue);
+                Assert.That(group.End.Handle.HasValue);
                 Assert.That(group.Nesting.Count(), Is.EqualTo(group.Nesting.Count));
             }
 
             foreach (var production in grammar.Productions)
             {
-                Assert.That(production.Head.HasValue);
+                Assert.That(production.Head.Handle.HasValue);
                 Assert.That(production.Members.Count(), Is.EqualTo(production.Members.Count));
             }
 

--- a/tests/Farkle.Tests.CSharp/TokenizerTests.cs
+++ b/tests/Farkle.Tests.CSharp/TokenizerTests.cs
@@ -32,7 +32,7 @@ namespace Farkle.Tests.CSharp
                 Assert.That(tokenizer.TryGetNextToken(ref reader, SyntaxChecker<char, object?>.Instance, out var token));
                 Assert.That(token.IsSuccess);
                 Assert.That(token.Position, Is.EqualTo(TextPosition.Initial));
-                Assert.That(grammar.GetString(grammar.GetTokenSymbol(token.Symbol).Name), Is.EqualTo(tokenName));
+                Assert.That(grammar.GetTokenSymbol(token.Symbol).Name, Is.EqualTo(tokenName));
             });
         }
 

--- a/tests/Farkle.Tests/GrammarBuilderTests.fs
+++ b/tests/Farkle.Tests/GrammarBuilderTests.fs
@@ -159,7 +159,7 @@ let tests = testList "Grammar builder tests" [
             let expectedName = sprintf "%s Renamed" df.Name
             let startSymbolName =
                 let grammar = df.Rename(expectedName).BuildSyntaxCheck().GetGrammar()
-                grammar.GetNonterminal(grammar.GrammarInfo.StartSymbol).Name |> grammar.GetString
+                grammar.GrammarInfo.StartSymbol.Name
             Expect.equal startSymbolName expectedName (sprintf "Renaming a %s had no effect" name)
 
         terminalU "Number" Regex.any
@@ -192,7 +192,6 @@ let tests = testList "Grammar builder tests" [
             grammar.Terminals
             |> Seq.exactlyOne
             |> _.Name
-            |> grammar.GetString
         Expect.equal terminalName "Test Renamed" "The renamed name of the symbol was not preferred"
     }
 
@@ -214,7 +213,6 @@ let tests = testList "Grammar builder tests" [
             grammar.Terminals
             |> Seq.exactlyOne
             |> _.Name
-            |> grammar.GetString
         // We can't know for sure which name will be chosen, but it will not be the original one.
         Expect.notEqual terminalName "Test" "The original name of a symbol was not preferred"
     }

--- a/tests/Farkle.Tests/GrammarEquivalenceTests.fs
+++ b/tests/Farkle.Tests/GrammarEquivalenceTests.fs
@@ -107,10 +107,10 @@ let createProductionMap (farkleGrammar: Grammar) (goldGrammar: Grammar) =
     let goldProductions = HashSet(goldProductions)
     Expect.hasLength farkleProductions goldProductions.Count "The two grammars don't have the same number of productions"
     for farkleProduction in farkleProductions do
-        let farkleProdHeadName = farkleGrammar.GetNonterminal(farkleProduction.Head).Name
+        let farkleProdHeadName = farkleProduction.Head.Name
         goldProductions
         |> Seq.tryFind (fun goldProduction ->
-            (goldGrammar.GetNonterminal(goldProduction.Head).Name) = farkleProdHeadName
+            (goldProduction.Head.Name) = farkleProdHeadName
             && string goldProduction = string farkleProduction)
         |> function
         | Some goldProduction ->
@@ -144,7 +144,7 @@ let recreateSyntaxFromGrammar (g: Grammar) =
         |> Array.ofSeq
         |> fun x -> nonterminals[idx].SetProductions(x))
     let parser =
-        nonterminals[g.GrammarInfo.StartSymbol.Value]
+        nonterminals[g.GrammarInfo.StartSymbol.Handle.Value]
             .AutoWhitespace(false)
             .WithGrammarName(g.GrammarInfo.Name)
             .BuildSyntaxCheck()

--- a/tests/Farkle.Tests/GrammarEquivalenceTests.fs
+++ b/tests/Farkle.Tests/GrammarEquivalenceTests.fs
@@ -64,29 +64,23 @@ let checkLALRStateTableEquivalence (productionMap: Dictionary<_, _>) (farkleGram
             let farkleState = farkleStates[i]
             let goldState = goldStates[lalrStates[i]]
 
-            let getTerminalName (grammar: Grammar) (term: TokenSymbolHandle) =
-                grammar.GetTokenSymbol(term).Name
-
             Expect.hasLength farkleState.Actions goldState.Actions.Count "There are not the same number of LALR actions"
             let actionsJoined =
                 farkleState.Actions.Join(
                     goldState.Actions,
-                    (fun (KeyValue(term, _)) -> getTerminalName farkleGrammar term),
-                    (fun (KeyValue(term, _)) -> getTerminalName goldGrammar term),
+                    (fun (KeyValue(term, _)) -> term.Name),
+                    (fun (KeyValue(term, _)) -> term.Name),
                     fun (KeyValue(_, farkleAction)) (KeyValue(_, goldAction)) -> farkleAction, goldAction)
             Expect.hasLength actionsJoined goldState.Actions.Count "Some terminals do not have a matching LALR action"
             for aFarkle, aGold in actionsJoined do
                 checkActionEquivalence aFarkle aGold
                 
-            let getNonterminalName (grammar: Grammar) (nont: NonterminalHandle) =
-                grammar.GetNonterminal(nont).Name
-
             Expect.hasLength farkleState.Gotos goldState.Gotos.Count "There are not the same number of LALR GOTO actions"
             let gotoJoined =
                 farkleState.Gotos.Join(
                     goldState.Gotos,
-                    (fun (KeyValue(nont, _)) -> getNonterminalName farkleGrammar nont),
-                    (fun (KeyValue(nont, _)) -> getNonterminalName goldGrammar nont),
+                    (fun (KeyValue(nont, _)) -> nont.Name),
+                    (fun (KeyValue(nont, _)) -> nont.Name),
                     fun (KeyValue(nont, farkleAction)) (KeyValue(_, goldAction)) -> nont, farkleAction, goldAction)
             Expect.hasLength gotoJoined goldState.Gotos.Count "Some nonterminals have no matching LALR GOTO action"
             for nont, gotoFarkle, gotoGold in gotoJoined do

--- a/tests/Farkle.Tests/GrammarEquivalenceTests.fs
+++ b/tests/Farkle.Tests/GrammarEquivalenceTests.fs
@@ -65,7 +65,7 @@ let checkLALRStateTableEquivalence (productionMap: Dictionary<_, _>) (farkleGram
             let goldState = goldStates[lalrStates[i]]
 
             let getTerminalName (grammar: Grammar) (term: TokenSymbolHandle) =
-                grammar.GetTokenSymbol(term).Name |> grammar.GetString
+                grammar.GetTokenSymbol(term).Name
 
             Expect.hasLength farkleState.Actions goldState.Actions.Count "There are not the same number of LALR actions"
             let actionsJoined =
@@ -79,7 +79,7 @@ let checkLALRStateTableEquivalence (productionMap: Dictionary<_, _>) (farkleGram
                 checkActionEquivalence aFarkle aGold
                 
             let getNonterminalName (grammar: Grammar) (nont: NonterminalHandle) =
-                grammar.GetNonterminal(nont).Name |> grammar.GetString
+                grammar.GetNonterminal(nont).Name
 
             Expect.hasLength farkleState.Gotos goldState.Gotos.Count "There are not the same number of LALR GOTO actions"
             let gotoJoined =
@@ -107,10 +107,10 @@ let createProductionMap (farkleGrammar: Grammar) (goldGrammar: Grammar) =
     let goldProductions = HashSet(goldProductions)
     Expect.hasLength farkleProductions goldProductions.Count "The two grammars don't have the same number of productions"
     for farkleProduction in farkleProductions do
-        let farkleProdHeadName = farkleGrammar.GetNonterminal(farkleProduction.Head).Name |> farkleGrammar.GetString
+        let farkleProdHeadName = farkleGrammar.GetNonterminal(farkleProduction.Head).Name
         goldProductions
         |> Seq.tryFind (fun goldProduction ->
-            (goldGrammar.GetNonterminal(goldProduction.Head).Name |> goldGrammar.GetString) = farkleProdHeadName
+            (goldGrammar.GetNonterminal(goldProduction.Head).Name) = farkleProdHeadName
             && string goldProduction = string farkleProduction)
         |> function
         | Some goldProduction ->
@@ -126,11 +126,11 @@ let checkParserEquivalence (farkleGrammar: Grammar) (goldGrammar: Grammar) =
 let recreateSyntaxFromGrammar (g: Grammar) =
     let terminals =
         g.Terminals
-        |> Seq.map (fun t -> t.Name |> g.GetString |> virtualTerminal)
+        |> Seq.map (fun t -> t.Name |> virtualTerminal)
         |> Array.ofSeq
     let nonterminals =
         g.Nonterminals
-        |> Seq.map (fun n -> n.Name |> g.GetString |> nonterminalU)
+        |> Seq.map (fun n -> n.Name |> nonterminalU)
         |> Array.ofSeq
     let getSymbol (x: EntityHandle) =
         if x.IsTokenSymbol then
@@ -146,7 +146,7 @@ let recreateSyntaxFromGrammar (g: Grammar) =
     let parser =
         nonterminals[g.GrammarInfo.StartSymbol.Value]
             .AutoWhitespace(false)
-            .WithGrammarName(g.GetString g.GrammarInfo.Name)
+            .WithGrammarName(g.GrammarInfo.Name)
             .BuildSyntaxCheck()
     if parser.IsFailing then
         failtestf "Failed to build: %O" (parser.Parse "")


### PR DESCRIPTION
* The `Name` property of grammar objects returns a string.
  * That string is also cached by the `Grammar` instance.
* Almost all grammar objects (except LR actions) return concrete grammar objects in their properties instead of handles.
* The grammar format specification was amended to allow readers to completely ignore unknown streams.
  * This enables streams to store custom data that do not influence the parser's behavior, without making the grammar unparsable if it has the `Critical` flag set.
  * Third-party extensions that do influence the parser's behavior must be placed in a state machine.
* Performance improvements.