### PR TITLE
Align OOB package versions with earliest targeted .NET version.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <FakeVersion>6.1.3</FakeVersion>
+    <!-- The version of out-of-band BCL packages that are referenced by shipping library projects.
+    Keep in line with the earliest supported .NET version. -->
+    <SystemOobVersion>8.0.0</SystemOobVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Argu" Version="6.2.5" />
@@ -39,7 +42,7 @@
     <PackageVersion Include="Sigourney.Build" Version="0.4.2" />
     <PackageVersion Include="Sigourney" Version="0.4.2" />
     <PackageVersion Include="System.Buffers" Version="4.6.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.4" />
+    <PackageVersion Include="System.Collections.Immutable" Version="$(SystemOobVersion)" />
     <PackageVersion Include="System.Memory" Version="4.6.0" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="9.0.4" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.0" />

--- a/src/Farkle/Farkle.csproj
+++ b/src/Farkle/Farkle.csproj
@@ -19,9 +19,11 @@
     <InternalsVisibleTo Include="Farkle.Tests.CSharp" />
     <PackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="all" />
     <PackageReference Include="PolySharp" PrivateAssets="all" />
-    <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="BitCollections" />
     <Using Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net8.0'))" Include="Farkle.Compatibility"/>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'netstandard2.1'))">
     <PackageReference Include="Microsoft.Bcl.HashCode" />


### PR DESCRIPTION
This PR makes the version we pick for our BCL out-of-band dependencies on downlevel frameworks deliberate.

On frameworks other than .NET, we depend on version `N.0.0`, where `N` is the earliest .NET version we target (currently 8). On .NET, we do not depend on these packages. Currently the only such package is immutable collections.

We will keep using the latest varsion of compatibility packages like `Microsoft.Bcl.***` or `System.Memory`.