### PR TITLE
Fix documentation `cref` tags.

### DIFF
--- a/src/Farkle/Parser/ParserState.cs
+++ b/src/Farkle/Parser/ParserState.cs
@@ -77,7 +77,7 @@ public struct ParserState
     internal readonly bool TokenizerSupportsSuspending =>
         (Attributes & ParserStateAttributes.TokenizerSupportsSuspending) != 0;
 
-    /// <inheritdoc cref="Tokenizers.TokenizerExtensions.IsSingleTokenizerInChain"/>
+    /// <inheritdoc cref="Tokenizers.ParserInputReaderTokenizerExtensions.IsSingleTokenizerInChain"/>
     internal readonly bool IsSingleTokenizerInChain =>
         (Attributes & ParserStateAttributes.HasMoreThanOneTokenizerInChain) == 0;
 

--- a/src/Farkle/Parser/Tokenizers/ITokenizerResumptionPoint.cs
+++ b/src/Farkle/Parser/Tokenizers/ITokenizerResumptionPoint.cs
@@ -13,7 +13,7 @@ namespace Farkle.Parser.Tokenizers;
 /// <typeparam name="TArg">A type a value of which will be passed to the resumption point.
 /// Implementing this interface with multiple <typeparamref name="TArg"/> types
 /// allows defining many suspension points.</typeparam>
-/// <seealso cref="TokenizerExtensions.SuspendTokenizer{TChar, TArg}(ref ParserInputReader{TChar}, ITokenizerResumptionPoint{TChar, TArg}, TArg)"/>
+/// <seealso cref="ParserInputReaderTokenizerExtensions.SuspendTokenizer{TChar, TArg}(ref ParserInputReader{TChar}, ITokenizerResumptionPoint{TChar, TArg}, TArg)"/>
 public interface ITokenizerResumptionPoint<TChar, in TArg>
 {
     /// <summary>
@@ -26,7 +26,7 @@ public interface ITokenizerResumptionPoint<TChar, in TArg>
     /// <param name="semanticProvider">An <see cref="ITokenSemanticProvider{TChar}"/>
     /// to create the semantic values for the tokens.</param>
     /// <param name="arg">The value that had been passed in
-    /// <see cref="TokenizerExtensions.SuspendTokenizer{TChar, TArg}(ref ParserInputReader{TChar}, ITokenizerResumptionPoint{TChar, TArg}, TArg)"/>.</param>
+    /// <see cref="ParserInputReaderTokenizerExtensions.SuspendTokenizer{TChar, TArg}(ref ParserInputReader{TChar}, ITokenizerResumptionPoint{TChar, TArg}, TArg)"/>.</param>
     /// <param name="result">Will hold the <see cref="TokenizerResult"/> if the method
     /// returns <see langword="true"/>.</param>
     /// <returns>Whether the tokenizer was given enough characters

--- a/src/Farkle/Parser/Tokenizers/Tokenizer.cs
+++ b/src/Farkle/Parser/Tokenizers/Tokenizer.cs
@@ -32,7 +32,7 @@ public abstract class Tokenizer<TChar>
     /// called by the parser, but the consequence is that suspending the tokenizer
     /// has no effect. It should therefore be used by tokenizers that are known to
     /// never suspend. An exception to this is when the tokenizer suspends by calling
-    /// <see cref="TokenizerExtensions.SuspendTokenizer{TChar}(ref ParserInputReader{TChar}, Tokenizer{TChar})"/>
+    /// <see cref="ParserInputReaderTokenizerExtensions.SuspendTokenizer{TChar}(ref ParserInputReader{TChar}, Tokenizer{TChar})"/>
     /// with a resumption point of <see langword="this"/>.
     /// </para>
     /// <para>


### PR DESCRIPTION
Missed from the rename in #380.