### PR TITLE
Fix automatic dependency submission workflow.

### DIFF
--- a/tests/Farkle.Tools.MSBuild.Tests/Farkle.Tools.MSBuild.Tests.csproj
+++ b/tests/Farkle.Tools.MSBuild.Tests/Farkle.Tools.MSBuild.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="../../src/Farkle/Farkle.fsproj" />
     <ProjectReference Include="../../sample/Farkle.Samples.FSharp/Farkle.Samples.FSharp.fsproj" />
-    <PackageReference Include="Farkle.Tools.MSBuild" VersionOverride="0.0.0-local" />
+    <!-- <PackageReference Include="Farkle.Tools.MSBuild" VersionOverride="0.0.0-local" /> -->
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/tests/Farkle.Tools.MSBuild.Tests/nuget.config
+++ b/tests/Farkle.Tools.MSBuild.Tests/nuget.config
@@ -4,6 +4,6 @@
     <add key="globalPackagesFolder" value="../packages" />
   </config>
   <packageSources>
-    <add key="Farkle Local" value="../packages" />
+    <!-- <add key="Farkle Local" value="../packages" /> -->
   </packageSources>
 </configuration>


### PR DESCRIPTION
The MSBuild integration tests are temporarily removed from the solution, but the workflow restores all projects files in the repository.