### PR TITLE
Clean up debugger displays and `ToString()` overrides et al.

### DIFF
--- a/src/Farkle/Builder/Dfa/DfaBuild.cs
+++ b/src/Farkle/Builder/Dfa/DfaBuild.cs
@@ -519,7 +519,6 @@ internal readonly struct DfaBuild<TChar> where TChar : unmanaged, IComparable<TC
             // this will slightly change behavior, but the impact is so small that it's not worth proactively
             // caring about.
             ReadOnlySpan<Regex> regexes = regex.IsAlt(out var altRegexes) ? altRegexes.AsSpan() : [regex];
-            // The regex contains Regex.Void somewhere.
             int? endLeafIndexTerminal = null, endLeafIndexLiteral = null;
             if (Symbols.GetName(i).Kind == TokenSymbolKind.Noise)
             {

--- a/src/Farkle/Builder/Regex.cs
+++ b/src/Farkle/Builder/Regex.cs
@@ -13,7 +13,7 @@ namespace Farkle.Builder;
 /// <summary>
 /// Represents a pattern that must be matched by terminals in a grammar.
 /// </summary>
-[DebuggerDisplay("{DebuggerDisplay,nq}")]
+[DebuggerDisplay("{DebuggerDisplay(),nq}")]
 public sealed class Regex
 {
     /*
@@ -88,39 +88,37 @@ public sealed class Regex
         Debug.Assert(N >= M);
     }
 
-    [DebuggerBrowsable(DebuggerBrowsableState.Never), ExcludeFromCodeCoverage]
-    private string DebuggerDisplay
+    [ExcludeFromCodeCoverage]
+    private string DebuggerDisplay()
     {
-        get
+        RuntimeHelpers.EnsureSufficientExecutionStack();
+        string caseString = (_kindAndFlags & KindAndFlags.CaseMask) switch
         {
-            string caseString = (_kindAndFlags & KindAndFlags.CaseMask) switch
-            {
-                KindAndFlags.CaseSensitive => " CaseSensitive",
-                KindAndFlags.CaseInsensitive => " CaseInsensitive",
-                _ => "",
-            };
-            string dataString = Kind switch
-            {
-                KindAndFlags.Any =>
-                    "Any",
-                KindAndFlags.StringLiteral =>
-                    $"\"{_data}\"",
-                KindAndFlags.Chars =>
-                    $"Chars[{(((char, char)[])_data!).Length}]",
-                KindAndFlags.AllButChars =>
-                    $"AllButChars[{(((char, char)[])_data!).Length}]",
-                KindAndFlags.Concat =>
-                    $"Concat[{((Regex[])_data!).Length}]",
-                KindAndFlags.Alt =>
-                    $"Alt[{((Regex[])_data!).Length}]",
-                KindAndFlags.Loop =>
-                    $"{((Regex)_data!).DebuggerDisplay}{{{M},{N}}}",
-                KindAndFlags.RegexString =>
-                    $"\"{_data}\"",
-                _ => ""
-            };
-            return $"{dataString}{caseString}";
-        }
+            KindAndFlags.CaseSensitive => " CaseSensitive",
+            KindAndFlags.CaseInsensitive => " CaseInsensitive",
+            _ => "",
+        };
+        string dataString = Kind switch
+        {
+            KindAndFlags.Any =>
+                "Any",
+            KindAndFlags.StringLiteral =>
+                $"\"{_data}\"",
+            KindAndFlags.Chars =>
+                $"Chars[{(((char, char)[])_data!).Length}]",
+            KindAndFlags.AllButChars =>
+                $"AllButChars[{(((char, char)[])_data!).Length}]",
+            KindAndFlags.Concat =>
+                $"Concat[{((Regex[])_data!).Length}]",
+            KindAndFlags.Alt =>
+                $"Alt[{((Regex[])_data!).Length}]",
+            KindAndFlags.Loop =>
+                $"{((Regex)_data!).DebuggerDisplay()}{{{M},{N}}}",
+            KindAndFlags.RegexString =>
+                $"\"{_data}\"",
+            _ => ""
+        };
+        return $"{dataString}{caseString}";
     }
 
     private Regex Loop(int m, int n)

--- a/src/Farkle/DebuggerTypeProxies.cs
+++ b/src/Farkle/DebuggerTypeProxies.cs
@@ -1,13 +1,10 @@
 // Copyright © Theodore Tsirpanis and Contributors.
 // SPDX-License-Identifier: MIT
 
-global using Farkle.DebuggerTypeProxies;
-using Farkle.Grammars;
-using Farkle.Grammars.StateMachines;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Farkle.DebuggerTypeProxies;
+namespace Farkle;
 
 [ExcludeFromCodeCoverage]
 internal class FlatCollectionProxy<T, TCollection>(TCollection list) where TCollection : IEnumerable<T>
@@ -16,79 +13,10 @@ internal class FlatCollectionProxy<T, TCollection>(TCollection list) where TColl
     public readonly T[] _items = list.ToArray();
 }
 
-[ExcludeFromCodeCoverage]
-internal class DfaProxy<TChar>(Dfa<TChar> dfa) : FlatCollectionProxy<DfaState<TChar>, Dfa<TChar>>(dfa);
-
-[ExcludeFromCodeCoverage]
-internal class DfaAcceptSymbolsProxy<TChar>(DfaState<TChar>.AcceptSymbolCollection collection) : FlatCollectionProxy<TokenSymbol, DfaState<TChar>.AcceptSymbolCollection>(collection);
-
-[ExcludeFromCodeCoverage]
-internal class DfaEdgesProxy<TChar>(DfaState<TChar>.EdgeCollection collection) : FlatCollectionProxy<DfaEdge<TChar>, DfaState<TChar>.EdgeCollection>(collection);
-
 [DebuggerDisplay("{Value,nq}", Name = "{Name,nq}")]
 [ExcludeFromCodeCoverage]
 internal readonly struct NameValuePair(string name, string value)
 {
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public readonly string Name = name, Value = value;
-}
-
-[ExcludeFromCodeCoverage]
-internal sealed class LrStateProxy
-{
-    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-    private readonly NameValuePair[] _actions;
-
-    public LrStateProxy(LrState state)
-    {
-        _actions = new NameValuePair[state.Actions.Count + state.EndOfFileActions.Count + state.Gotos.Count];
-
-        Grammar grammar = state.Grammar;
-        int i = 0;
-        foreach (var action in state.Actions)
-        {
-            _actions[i++] = new NameValuePair(action.Key.ToString(), action.Value.ToString(grammar));
-        }
-        foreach (var action in state.EndOfFileActions)
-        {
-            _actions[i++] = new NameValuePair("(EOF)", action.ToString(grammar));
-        }
-        foreach (var @goto in state.Gotos)
-        {
-            _actions[i++] = new NameValuePair(@goto.Key.ToString(), $"Goto state {@goto.Value}");
-        }
-        Debug.Assert(i == _actions.Length);
-    }
-}
-
-[ExcludeFromCodeCoverage]
-internal sealed class DfaStateProxy<TChar>
-{
-    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-    private readonly NameValuePair[] _actions;
-
-    public DfaStateProxy(DfaState<TChar> state)
-    {
-        int defaultTransition = state.DefaultTransition;
-
-        _actions = new NameValuePair[state.Edges.Count + (defaultTransition != -1 ? 1 : 0) + state.AcceptSymbols.Count];
-
-        int i = 0;
-        foreach (var edge in state.Edges)
-        {
-            string key = EqualityComparer<TChar>.Default.Equals(edge.KeyFrom, edge.KeyTo)
-                ? $"{DfaEdge<TChar>.Format(edge.KeyFrom)}"
-                : $"[{DfaEdge<TChar>.Format(edge.KeyFrom)},{DfaEdge<TChar>.Format(edge.KeyTo)}]";
-            string value = edge.Target < 0 ? "Fail" : $"Goto state {edge.Target}";
-            _actions[i++] = new NameValuePair(key, value);
-        }
-        if (defaultTransition >= 0)
-        {
-            _actions[i++] = new NameValuePair(i > 0 ? "In all other cases" : "Always", $"Goto state {defaultTransition}");
-        }
-        foreach (var accept in state.AcceptSymbols)
-        {
-            _actions[i++] = new NameValuePair("Accept", accept.ToString());
-        }
-    }
 }

--- a/src/Farkle/Grammars/DebuggerTypeProxies.cs
+++ b/src/Farkle/Grammars/DebuggerTypeProxies.cs
@@ -67,7 +67,8 @@ internal sealed class DfaStateProxy<TChar>
         }
         if (defaultTransition >= 0)
         {
-            _actions[i++] = new NameValuePair(i > 0 ? "In all other cases" : "Always", $"Goto state {defaultTransition}");
+            string name = i > 0 ? "In all other cases" : "Always";
+            _actions[i++] = new NameValuePair(name, $"Goto state {defaultTransition}");
         }
         foreach (var accept in state.AcceptSymbols)
         {

--- a/src/Farkle/Grammars/DebuggerTypeProxies.cs
+++ b/src/Farkle/Grammars/DebuggerTypeProxies.cs
@@ -1,0 +1,77 @@
+// Copyright © Theodore Tsirpanis and Contributors.
+// SPDX-License-Identifier: MIT
+
+using Farkle.Grammars.StateMachines;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Farkle.Grammars;
+
+[ExcludeFromCodeCoverage]
+internal class DfaProxy<TChar>(Dfa<TChar> dfa) : FlatCollectionProxy<DfaState<TChar>, Dfa<TChar>>(dfa);
+
+[ExcludeFromCodeCoverage]
+internal class DfaAcceptSymbolsProxy<TChar>(DfaState<TChar>.AcceptSymbolCollection collection) : FlatCollectionProxy<TokenSymbol, DfaState<TChar>.AcceptSymbolCollection>(collection);
+
+[ExcludeFromCodeCoverage]
+internal class DfaEdgesProxy<TChar>(DfaState<TChar>.EdgeCollection collection) : FlatCollectionProxy<DfaEdge<TChar>, DfaState<TChar>.EdgeCollection>(collection);
+
+[ExcludeFromCodeCoverage]
+internal sealed class LrStateProxy
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    private readonly NameValuePair[] _actions;
+
+    public LrStateProxy(LrState state)
+    {
+        _actions = new NameValuePair[state.Actions.Count + state.EndOfFileActions.Count + state.Gotos.Count];
+
+        Grammar grammar = state.Grammar;
+        int i = 0;
+        foreach (var action in state.Actions)
+        {
+            _actions[i++] = new NameValuePair(action.Key.ToString(), action.Value.ToString(grammar));
+        }
+        foreach (var action in state.EndOfFileActions)
+        {
+            _actions[i++] = new NameValuePair("(EOF)", action.ToString(grammar));
+        }
+        foreach (var @goto in state.Gotos)
+        {
+            _actions[i++] = new NameValuePair(@goto.Key.ToString(), $"Goto state {@goto.Value}");
+        }
+        Debug.Assert(i == _actions.Length);
+    }
+}
+
+[ExcludeFromCodeCoverage]
+internal sealed class DfaStateProxy<TChar>
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    private readonly NameValuePair[] _actions;
+
+    public DfaStateProxy(DfaState<TChar> state)
+    {
+        int defaultTransition = state.DefaultTransition;
+
+        _actions = new NameValuePair[state.Edges.Count + (defaultTransition != -1 ? 1 : 0) + state.AcceptSymbols.Count];
+
+        int i = 0;
+        foreach (var edge in state.Edges)
+        {
+            string key = EqualityComparer<TChar>.Default.Equals(edge.KeyFrom, edge.KeyTo)
+                ? $"{DfaEdge<TChar>.Format(edge.KeyFrom)}"
+                : $"[{DfaEdge<TChar>.Format(edge.KeyFrom)},{DfaEdge<TChar>.Format(edge.KeyTo)}]";
+            string value = edge.Target < 0 ? "Fail" : $"Goto state {edge.Target}";
+            _actions[i++] = new NameValuePair(key, value);
+        }
+        if (defaultTransition >= 0)
+        {
+            _actions[i++] = new NameValuePair(i > 0 ? "In all other cases" : "Always", $"Goto state {defaultTransition}");
+        }
+        foreach (var accept in state.AcceptSymbols)
+        {
+            _actions[i++] = new NameValuePair("Accept", accept.ToString());
+        }
+    }
+}

--- a/src/Farkle/Grammars/EntityHandle.cs
+++ b/src/Farkle/Grammars/EntityHandle.cs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Farkle.Grammars;
 
 /// <summary>
 /// Points to a table row of a <see cref="Grammar"/>.
 /// </summary>
+[DebuggerDisplay("{DebuggerDisplay(),nq}")]
 public readonly struct EntityHandle : IEquatable<EntityHandle>
 {
     internal const int ValueSize = 24;
@@ -37,6 +39,9 @@ public readonly struct EntityHandle : IEquatable<EntityHandle>
         }
     }
 
+    [ExcludeFromCodeCoverage]
+    private string DebuggerDisplay() => HasValue ? $"{Kind} {TableIndex + 1}" : "<null>";
+
     /// <summary>
     /// Whether this <see cref="EntityHandle"/> has a valid value.
     /// </summary>
@@ -65,11 +70,6 @@ public readonly struct EntityHandle : IEquatable<EntityHandle>
 
     /// <inheritdoc/>
     public override int GetHashCode() => _valueAndKind.GetHashCode();
-
-    /// <summary>
-    /// Returns a string describing the the <see cref="EntityHandle"/>.
-    /// </summary>
-    public override string ToString() => HasValue ? $"{Kind} {TableIndex + 1}" : "<null>";
 
     /// <summary>
     /// Checks if two <see cref="EntityHandle"/>s are pointing to the same table row.

--- a/src/Farkle/Grammars/Grammar.cs
+++ b/src/Farkle/Grammars/Grammar.cs
@@ -330,6 +330,32 @@ public abstract partial class Grammar : IGrammarProvider
     }
 
     /// <summary>
+    /// Gets a boxed object representing the entity pointed to by the given <see cref="EntityHandle"/>.
+    /// </summary>
+    /// <param name="handle">A handle to the entity.</param>
+    /// <remarks>
+    /// This method must not be called in performance-critical code.
+    /// </remarks>
+    internal object? GetEntity(EntityHandle handle)
+    {
+        if (handle.IsTokenSymbol)
+        {
+            return GetTokenSymbol((TokenSymbolHandle)handle);
+        }
+        if (handle.IsNonterminal)
+        {
+            return GetNonterminal((NonterminalHandle)handle);
+        }
+        if (handle.IsProduction)
+        {
+            return GetProduction((ProductionHandle)handle);
+        }
+
+        Debug.Assert(!handle.HasValue);
+        return null;
+    }
+
+    /// <summary>
     /// Looks up a token symbol or nonterminal with the specified special name.
     /// </summary>
     /// <param name="specialName">The symbol's special name.</param>

--- a/src/Farkle/Grammars/GrammarInfo.cs
+++ b/src/Farkle/Grammars/GrammarInfo.cs
@@ -9,7 +9,7 @@ namespace Farkle.Grammars;
 /// Contains general information about a <see cref="Grammar"/>.
 /// </summary>
 /// <seealso cref="Grammar.GrammarInfo"/>
-[DebuggerDisplay("Name = {_grammar.GetString(Name)}; StartSymbol = {_grammar.GetNonterminal(StartSymbol)}; Attributes = {Attributes}")]
+[DebuggerDisplay("Name = {Name,nq}; StartSymbol = {StartSymbol}; Attributes = {Attributes}")]
 public readonly struct GrammarInfo
 {
     private readonly Grammar _grammar { get; }

--- a/src/Farkle/Grammars/NonterminalHandle.cs
+++ b/src/Farkle/Grammars/NonterminalHandle.cs
@@ -1,6 +1,9 @@
 // Copyright © Theodore Tsirpanis and Contributors.
 // SPDX-License-Identifier: MIT
 
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
 namespace Farkle.Grammars;
 
 /// <summary>
@@ -11,6 +14,7 @@ namespace Farkle.Grammars;
 /// of use when parsing. To get any information about the nonterminal you have to pass it to the
 /// <see cref="Grammar.GetNonterminal"/> method.</para>
 /// </remarks>
+[DebuggerDisplay("{DebuggerDisplay(),nq}")]
 public readonly struct NonterminalHandle : IEquatable<NonterminalHandle>
 {
     internal uint TableIndex { get; }
@@ -43,6 +47,9 @@ public readonly struct NonterminalHandle : IEquatable<NonterminalHandle>
     /// <seealso cref="Value"/>
     public bool HasValue => TableIndex != 0;
 
+    [ExcludeFromCodeCoverage]
+    private string DebuggerDisplay() => HasValue ? Value.ToString() : "<null>";
+
     /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is NonterminalHandle handle && Equals(handle);
 
@@ -51,11 +58,6 @@ public readonly struct NonterminalHandle : IEquatable<NonterminalHandle>
 
     /// <inheritdoc/>
     public override int GetHashCode() => TableIndex.GetHashCode();
-
-    /// <summary>
-    /// Returns a string describing the the <see cref="NonterminalHandle"/>.
-    /// </summary>
-    public override string ToString() => HasValue ? Value.ToString() : "<null>";
 
     /// <summary>
     /// Checks if two <see cref="NonterminalHandle"/>s are pointing to the same row.

--- a/src/Farkle/Grammars/Production.cs
+++ b/src/Farkle/Grammars/Production.cs
@@ -84,6 +84,11 @@ public readonly struct Production : IEquatable<Production>
     /// </summary>
     public override string ToString()
     {
+        if (_grammar is null)
+        {
+            return "";
+        }
+
         StringBuilder sb = new();
 
         sb.Append(Head);

--- a/src/Farkle/Grammars/Production.cs
+++ b/src/Farkle/Grammars/Production.cs
@@ -96,14 +96,7 @@ public readonly struct Production : IEquatable<Production>
         foreach (EntityHandle member in Members)
         {
             sb.Append(' ');
-            if (member.IsTokenSymbol)
-            {
-                sb.Append(_grammar.GetTokenSymbol((TokenSymbolHandle)member));
-            }
-            else
-            {
-                sb.Append(_grammar.GetNonterminal((NonterminalHandle)member));
-            }
+            sb.Append(_grammar.GetEntity(member));
         }
 
         return sb.ToString();

--- a/src/Farkle/Grammars/ProductionHandle.cs
+++ b/src/Farkle/Grammars/ProductionHandle.cs
@@ -1,6 +1,9 @@
 // Copyright © Theodore Tsirpanis and Contributors.
 // SPDX-License-Identifier: MIT
 
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
 namespace Farkle.Grammars;
 
 /// <summary>
@@ -11,6 +14,7 @@ namespace Farkle.Grammars;
 /// of use when parsing. To get any information about the production you have to pass it to the
 /// <see cref="Grammar.GetProduction"/> method.</para>
 /// </remarks>
+[DebuggerDisplay("{DebuggerDisplay(),nq}")]
 public readonly struct ProductionHandle : IEquatable<ProductionHandle>
 {
     internal uint TableIndex { get; }
@@ -43,6 +47,9 @@ public readonly struct ProductionHandle : IEquatable<ProductionHandle>
     /// <seealso cref="Value"/>
     public bool HasValue => TableIndex != 0;
 
+    [ExcludeFromCodeCoverage]
+    private string DebuggerDisplay() => HasValue ? Value.ToString() : "<null>";
+
     /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is ProductionHandle handle && Equals(handle);
 
@@ -51,11 +58,6 @@ public readonly struct ProductionHandle : IEquatable<ProductionHandle>
 
     /// <inheritdoc/>
     public override int GetHashCode() => TableIndex.GetHashCode();
-
-    /// <summary>
-    /// Returns a string describing the the <see cref="ProductionHandle"/>.
-    /// </summary>
-    public override string ToString() => HasValue ? Value.ToString() : "<null>";
 
     /// <summary>
     /// Checks if two <see cref="ProductionHandle"/>s are pointing to the same row.

--- a/src/Farkle/Grammars/SpecialNameDefinition.cs
+++ b/src/Farkle/Grammars/SpecialNameDefinition.cs
@@ -9,7 +9,7 @@ namespace Farkle.Grammars;
 /// <summary>
 /// Represents an entry in the <c>SpecialName</c> table of a <see cref="Grammar"/>.
 /// </summary>
-[DebuggerDisplay("{DebuggerDisplay,nq}")]
+[DebuggerDisplay("{DebuggerDisplay(),nq}")]
 public readonly struct SpecialNameDefinition : IEquatable<SpecialNameDefinition>
 {
     private readonly Grammar _grammar;
@@ -23,15 +23,7 @@ public readonly struct SpecialNameDefinition : IEquatable<SpecialNameDefinition>
     }
 
     [ExcludeFromCodeCoverage]
-    private string DebuggerDisplay
-    {
-        get
-        {
-            var symbol = Symbol;
-            string symbolName = symbol.IsTokenSymbol ? _grammar.GetTokenSymbol((TokenSymbolHandle)symbol).ToString() : _grammar.GetNonterminal((NonterminalHandle)symbol).ToString();
-            return $"{Name} → {symbolName}";
-        }
-    }
+    private string DebuggerDisplay() => _grammar is null ? "<null>" : $"Name = {Name}; Symbol = {_grammar.GetEntity(Symbol)}";
 
     [StackTraceHidden]
     private void AssertHasValue()

--- a/src/Farkle/Grammars/StateMachines/LrAction.cs
+++ b/src/Farkle/Grammars/StateMachines/LrAction.cs
@@ -111,22 +111,6 @@ public readonly struct LrAction : IEquatable<LrAction>
     /// <inheritdoc/>
     public override int GetHashCode() => Value;
 
-    /// <inheritdoc/>
-    public override string ToString()
-    {
-        if (IsShift)
-        {
-            return $"Shift to state {ShiftState}";
-        }
-
-        if (IsReduce)
-        {
-            return $"Reduce production {ReduceProduction.TableIndex}";
-        }
-
-        return "Error";
-    }
-
     internal string ToString(Grammar grammar)
     {
         if (IsShift)

--- a/src/Farkle/Grammars/StateMachines/LrEndOfFileAction.cs
+++ b/src/Farkle/Grammars/StateMachines/LrEndOfFileAction.cs
@@ -84,22 +84,6 @@ public readonly struct LrEndOfFileAction : IEquatable<LrEndOfFileAction>
     /// <inheritdoc/>
     public override int GetHashCode() => (int)Value;
 
-    /// <inheritdoc/>
-    public override string ToString()
-    {
-        if (IsReduce)
-        {
-            return $"Reduce production {ReduceProduction.TableIndex}";
-        }
-
-        if (IsAccept)
-        {
-            return "Accept";
-        }
-
-        return "Error";
-    }
-
     internal string ToString(Grammar grammar)
     {
         if (IsReduce)

--- a/src/Farkle/Grammars/TokenSymbolHandle.cs
+++ b/src/Farkle/Grammars/TokenSymbolHandle.cs
@@ -1,6 +1,9 @@
 // Copyright © Theodore Tsirpanis and Contributors.
 // SPDX-License-Identifier: MIT
 
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
 namespace Farkle.Grammars;
 
 /// <summary>
@@ -11,6 +14,7 @@ namespace Farkle.Grammars;
 /// of use when parsing. To get any information about the token symbol you have to pass it to the
 /// <see cref="Grammar.GetTokenSymbol"/> method.</para>
 /// </remarks>
+[DebuggerDisplay("{DebuggerDisplay(),nq}")]
 public readonly struct TokenSymbolHandle : IEquatable<TokenSymbolHandle>
 {
     internal uint TableIndex { get; }
@@ -43,6 +47,9 @@ public readonly struct TokenSymbolHandle : IEquatable<TokenSymbolHandle>
     /// <seealso cref="Value"/>
     public bool HasValue => TableIndex != 0;
 
+    [ExcludeFromCodeCoverage]
+    private string DebuggerDisplay() => HasValue ? Value.ToString() : "<null>";
+
     /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is TokenSymbolHandle handle && Equals(handle);
 
@@ -51,11 +58,6 @@ public readonly struct TokenSymbolHandle : IEquatable<TokenSymbolHandle>
 
     /// <inheritdoc/>
     public override int GetHashCode() => TableIndex.GetHashCode();
-
-    /// <summary>
-    /// Returns a string describing the the <see cref="TokenSymbolHandle"/>.
-    /// </summary>
-    public override string ToString() => HasValue ? Value.ToString() : "<null>";
 
     /// <summary>
     /// Checks if two <see cref="TokenSymbolHandle"/>s are pointing to the same row.

--- a/src/Farkle/ParserResult.cs
+++ b/src/Farkle/ParserResult.cs
@@ -60,7 +60,7 @@ public readonly struct ParserResult<T> : IFormattable
     /// <summary>
     /// Converts the <see cref="ParserResult{T}"/>'s success or error value to a string.
     /// </summary>
-    public override string? ToString() => ToString(null, null);
+    public override string ToString() => ToString(null, null);
 
     /// <summary>
     /// Whether the <see cref="ParserResult{T}"/> represents success.


### PR DESCRIPTION
With this PR, only the following types override `ToString()`, and other types that want to be debugger-friendly were updated to use `DebuggerDisplay`:

* All relevant `Farkle.Diagnostics` types.
* `TokenSymbol`
* `Nonterminal`
* `Production`
* `Group`

The last four types are structs, and calling to `String()` on their `default` value returns an empty string. This matches appending `null` to a string builder.