### PR TITLE
[release/6.0] Publish site to its own domain.

### DIFF
--- a/.github/workflows/docs-v6.yml
+++ b/.github/workflows/docs-v6.yml
@@ -1,0 +1,61 @@
+name: Publish documentation (v6)
+
+on:
+  push:
+    branches:
+      - release/6.0
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 6.0.x
+      - name: Restore .NET local tools
+        run: dotnet tool restore
+      - name: Build documentation
+        run: dotnet run --project eng/Farkle.Build.fsproj -- -t GenerateDocs
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site
+          path: _site
+          retention-days: 1
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: v6-docs
+      url: ${{ steps.site-url.outputs.page_url }}
+    steps:
+      - name: Checkout v6 site repository
+        uses: actions/checkout@v5
+        with:
+          repository: farkle-parser/docs-v6
+          ref: gh-pages
+          ssh-key: ${{ secrets.PAGES_DEPLOY_KEY }}
+      - name: Clear repository files
+        run: rm -rf ./*
+      - name: Download site
+        uses: actions/download-artifact@v5
+        with:
+          name: site
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -a --amend -m "Publish documentation from commit ${{ github.sha }}" || echo "No changes to commit"
+          git push --force
+      - name: Get site URL
+        id: site-url
+        run: echo "page_url=https://$(cat CNAME)" >> $GITHUB_OUTPUT

--- a/.gitignore
+++ b/.gitignore
@@ -181,7 +181,7 @@ docs/release-notes.md
 
 docs.zip
 *.nupkg
-output/
+_site/
 **/BenchmarkDotNet.Artifacts/
 temp/
 tmp/

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+v6.farkle.dev

--- a/docs/_template.html
+++ b/docs/_template.html
@@ -8,9 +8,9 @@
   <meta name="description" content="Farkle - {{fsdocs-page-title}}">
 
   <link rel="stylesheet" id="theme_link" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.0/materia/bootstrap.min.css">
-  <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha384-vtXRMe3mGCbOeY7l30aIg8H9p3GdeSe4IFlP6G8JMa7o7lXvnz3GFKzPxzJdPfGK" crossorigin="anonymous"></script>
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs" crossorigin="anonymous"></script>
   <script async src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.min.js" integrity="sha384-+YQ4JLhjyBLPDQt//I+STsc9iw4uQqACwlvpslubQzn4u2UU2UFM80nGisd026JF" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous"></script>
 
   <link type="text/css" rel="stylesheet" href="{{root}}content/navbar-{{fsdocs-navbar-position}}.css" />
   <link type="text/css" rel="stylesheet" href="{{root}}content/fsdocs-{{fsdocs-theme}}.css" />
@@ -69,10 +69,10 @@
     </div>
 
     <!-- BEGIN SEARCH BOX: this adds support for the search box -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/JavaScript-autoComplete/1.0.4/auto-complete.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/JavaScript-autoComplete/1.0.5/auto-complete.css" />
     <script type="text/javascript">var fsdocs_search_baseurl = '{{root}}';</script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.3.8/lunr.min.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/JavaScript-autoComplete/1.0.4/auto-complete.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.3.9/lunr.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/JavaScript-autoComplete/1.0.5/auto-complete.min.js"></script>
     <script async type="text/javascript" src="{{root}}content/fsdocs-search.js"></script>
     <!-- END SEARCH BOX: this adds support for the search box -->
   </body>

--- a/docs/_template.html
+++ b/docs/_template.html
@@ -22,6 +22,9 @@
 </head>
 
   <body>
+    <div class="alert alert-info" role="alert">
+      <h4 class="text-center">The next version of Farkle is in preview! Check out its <a href="https://farkle.dev">documentation</a>, and <a href="https://farkle.dev/migration/60-70.html">migrate your projects</a>.</h4>
+    </div>
     <nav class="navbar navbar-expand-md navbar-light bg-secondary {{fsdocs-navbar-position}}" id="fsdocs-nav">
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>

--- a/eng/build.fs
+++ b/eng/build.fs
@@ -327,7 +327,7 @@ let generateDocs doWatch isRelease =
     let fsDocsCommand = if doWatch then "watch" else "build"
     let root = root isRelease
 
-    (sprintf "%s --clean --output \"%s\" --properties FsFormatting=true %s" fsDocsCommand docsOutput root)
+    sprintf "%s --clean --output \"%s\" --properties FsFormatting=true %s" fsDocsCommand docsOutput root
     |> DotNet.exec id "fsdocs"
     |> handleFailure
 

--- a/eng/build.fs
+++ b/eng/build.fs
@@ -309,7 +309,7 @@ Target.create "NuGetPack" (fun _ ->
 let repoRoot = Path.getDirectory __SOURCE_DIRECTORY__
 
 let referenceDocsTempPath = repoRoot @@ "temp/referencedocs-publish"
-let docsOutput = repoRoot @@ "output/"
+let docsOutput = repoRoot @@ "_site/"
 
 let root isRelease =
     match isRelease with
@@ -352,11 +352,7 @@ Target.create "KeepGeneratingDocs" (fun _ ->
 )
 
 Target.description "Generates the website for the project - for release"
-Target.create "GenerateDocs" (fun _ ->
-    generateDocs false true
-    !! (docsOutput @@ "**") |> Zip.zip docsOutput "docs.zip"
-    Trace.publish ImportData.BuildArtifact "docs.zip"
-)
+Target.create "GenerateDocs" (fun _ -> generateDocs false true)
 Target.description "Generates the website for the project - for local use"
 Target.create "GenerateDocsDebug" (fun _ -> generateDocs false false)
 

--- a/src/NuGet.props
+++ b/src/NuGet.props
@@ -3,7 +3,7 @@
     <Authors>Theodore Tsirpanis</Authors>
     <Copyright>Copyright © 2017 Theodore Tsirpanis. Licensed under the MIT License.</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://teo-tsirpanis.github.io/Farkle/</PackageProjectUrl>
+    <PackageProjectUrl>https://v6.farkle.dev/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/teo-tsirpanis/Farkle/master/docs/img/logo.png</PackageIconUrl>
     <PackageIcon>logo.png</PackageIcon>
     <PackageTags>farkle;parser;lalr;gold-parser</PackageTags>


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to publish the site of Farkle 6.x. The site gets pushed to https://github.com/farkle-parser/docs-v6, and has a custom domain of https://v6.farkle.dev.