### PR TITLE
Remove .NET Standard 2.0 support.

### DIFF
--- a/docs/docs/migration/60-70.md
+++ b/docs/docs/migration/60-70.md
@@ -12,6 +12,12 @@ Usually, this will be the majority of the work you need to do. After you do that
 
 The following changes were made in Farkle 7.0 that might affect compatibility with Farkle 6.x.
 
+### General changes
+
+* Farkle was rewritten in C#. F# remains a supported language, and the F# API is provided through a source file automatically included by the NuGet package.
+* Support for .NET Standard 2.0 was removed, and the minimum target framework was increased to .NET Standard 2.1. This is expected to change when [Unity adds support for CoreCLR][unity-coreclr], after which Farkle will target only .NET according to the [.NET support lifecycle][dotnet-support].
+  * Keeping .NET Standard 2.0 support for a little longer is a possibility, depending on ecosystem developments and community feedback. If you need to run Farkle on a .NET Standard 2.0-compatible framework, please open an issue.
+
 ### Changes to the builder API
 
 * The type `DesigntimeFarkle<T>` was split into two types; @"Farkle.Builder.IGrammarBuilder\`1" and @"Farkle.Builder.IGrammarSymbol\`1", where the latter inherits from the former. The untyped `DesigntimeFarkle` type got an equivalent treatment. Grammar builders cannot be used as members of a production, while grammar symbols can. This is used to enforce that customization options that apply to the whole grammar must be set at the top-most symbol that gets built.
@@ -61,5 +67,7 @@ The language of string regexes has been updated to be more in line with standard
   * The `productions_groupped` helper variable was removed; getting the productions of a nonterminal is now built-in, and available with the @"Farkle.Grammars.Nonterminal.Productions?displayProperty=nameWithType" property.
 * The `fmt` function was removed.
 
+[unity-coreclr]: https://discussions.unity.com/t/coreclr-and-net-modernization-unite-2024/1519272
+[dotnet-support]: https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core
 [tokenizer-design]: https://github.com/teo-tsirpanis/Farkle/blob/mainstream/designs/7.0/tokenizer-api.md
 [indent-based]: https://github.com/teo-tsirpanis/Farkle/blob/mainstream/sample/Farkle.Samples.FSharp/IndentBased.fs

--- a/src/Farkle.Tools.Shared/Farkle.Tools.Shared.fsproj
+++ b/src/Farkle.Tools.Shared/Farkle.Tools.Shared.fsproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <!-- <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks> -->
+    <TargetFramework>netstandard2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);MONADS_PUBLIC</DefineConstants>
   </PropertyGroup>

--- a/src/Farkle/Farkle.csproj
+++ b/src/Farkle/Farkle.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../NuGet.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <!-- <TargetFrameworks>net9.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks> -->
+    <TargetFrameworks>net9.0;net8.0;netstandard2.1</TargetFrameworks>
     <LangVersion>13</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tests/Farkle.Tests.CSharp/Farkle.Tests.CSharp.csproj
+++ b/tests/Farkle.Tests.CSharp/Farkle.Tests.CSharp.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">net8.0;net48</TargetFrameworks>
-    <TargetFramework Condition="!$([MSBuild]::IsOsPlatform('Windows'))">net8.0</TargetFramework>
+    <!-- <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">net8.0;net48</TargetFrameworks>
+    <TargetFramework Condition="!$([MSBuild]::IsOsPlatform('Windows'))">net8.0</TargetFramework> -->
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>13</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Following the trend of removing things that might not be actually needed, this PR removes .NET Standard 2.0 support from Farkle 7.

Supporting .NET Standard 2.0 is not easy, and requires several polyfills. Its removal has long been contingent on MSBuild's support of running .NET tasks on .NET Framework hosts (like Visual Studio). This is [expected to ship by .NET 10 GA](https://x.com/ChetHusk/status/1960859810036900123), so we can be preëmptive and remove it now, before releasing the preview.

The PR only removes targeting NS 2.0 from the project files, and does not change any code. This means that we can revisit the decision until Farkle 7.0 GA.