### PR TITLE
Update migration guide et al.

### DIFF
--- a/docs/docs/migration/60-70.md
+++ b/docs/docs/migration/60-70.md
@@ -26,6 +26,7 @@ The following changes were made in Farkle 7.0 that might affect compatibility wi
 * In grammars with the @"Farkle.Builder.Terminal.NewLine" symbol that have not disabled automatic whitespace handling, new lines in unexpected places are ignored by default and do not produce a syntax error. You can customize this behavior by using the newly introduced @"Farkle.Builder.GrammarBuilderExtensions.NewLineIsNoisy*" extension methods.
 * Each grammar can have up to one @"Farkle.Builder.OperatorPrecedence.OperatorScope", which must be set at the top-most symbol that gets built.
 * In the F# API, fusers can have up to 6 parameters, instead of 16. If you need more parameters, you have to either refactor your grammar, or write the production with the C# API.
+* In the F# API's `Farkle.Builder.Terminals` module, the `genericSigned`, `genericUnsigned`, and `genericReal` functions are supported only when targeting a supported version of .NET. Using them when targeting earlier frameworks will result in a compile-time error.
 * @"Farkle.Builder.Regex.Any?displayProperty=nameWithType" was updated to match exactly any character, and no longer has lower priority than other character classes.
 * The `Farkle.Builder.PredefinedSets` type was removed. If you were using it, you have to specify the character set yourself.
 

--- a/docs/docs/migration/60-70.md
+++ b/docs/docs/migration/60-70.md
@@ -17,6 +17,7 @@ The following changes were made in Farkle 7.0 that might affect compatibility wi
 * Farkle was rewritten in C#. F# remains a supported language, and the F# API is provided through a source file automatically included by the NuGet package.
 * Support for .NET Standard 2.0 was removed, and the minimum target framework was increased to .NET Standard 2.1. This is expected to change when [Unity adds support for CoreCLR][unity-coreclr], after which Farkle will target only .NET according to the [.NET support lifecycle][dotnet-support].
   * Keeping .NET Standard 2.0 support for a little longer is a possibility, depending on ecosystem developments and community feedback. If you need to run Farkle on a .NET Standard 2.0-compatible framework, please open an issue.
+* Instead of a discriminated union, parser and builder errors have a type of `object`, and can be converted to a human-readable message by calling `ToString()`. For certain error types carrying additional information, you can try casting the error object to one of the types defined in the @"Farkle.Diagnostics" namespace. There are some active patterns to help F# users.
 
 ### Changes to the builder API
 
@@ -26,7 +27,7 @@ The following changes were made in Farkle 7.0 that might affect compatibility wi
 * In grammars with the @"Farkle.Builder.Terminal.NewLine" symbol that have not disabled automatic whitespace handling, new lines in unexpected places are ignored by default and do not produce a syntax error. You can customize this behavior by using the newly introduced @"Farkle.Builder.GrammarBuilderExtensions.NewLineIsNoisy*" extension methods.
 * Each grammar can have up to one @"Farkle.Builder.OperatorPrecedence.OperatorScope", which must be set at the top-most symbol that gets built.
 * In the F# API, fusers can have up to 6 parameters, instead of 16. If you need more parameters, you have to either refactor your grammar, or write the production with the C# API.
-* In the F# API's `Farkle.Builder.Terminals` module, the `genericSigned`, `genericUnsigned`, and `genericReal` functions are supported only when targeting a supported version of .NET. Using them when targeting earlier frameworks will result in a compile-time error.
+* In the F# API's `Farkle.Builder.Terminals` module, the `genericSigned`, `genericUnsigned`, and `genericReal` functions are available only when targeting a supported version of .NET. Using them when targeting earlier frameworks will result in a compile error.
 * In the F# API's `Terminals.stringEx` function, the `allowEscapeUnicode` parameter was removed. If you want to support escaping Unicode characters, include the `u` character in the `escapeChars` parameter.
 * @"Farkle.Builder.Regex.Any?displayProperty=nameWithType" was updated to match exactly any character, and no longer has lower priority than other character classes.
 * The `Farkle.Builder.PredefinedSets` type was removed. If you were using it, you have to specify the character set yourself.
@@ -50,8 +51,7 @@ The language of string regexes has been updated to be more in line with standard
 
 * The `RuntimeFarkle<T>` type was renamed to @"Farkle.CharParser`1".
 * The `PostProcessor<T>` type was renamed to @"Farkle.Parser.Semantics.ISemanticProvider`2" and can support other character types, for future extensibility.
-* Instead of an F# `Result`, the parser functions return values of type @"Farkle.ParserResult`1".
-* Instead of a discriminated union, parser errors have a type of `object`, and can be converted to a human-readable message by calling `ToString()`. For some specific error types, you can try casting the error object to one of the types defined in the @"Farkle.Diagnostics.Oriskany" namespace.
+* Instead of an F# `Result`, the parser functions return values of type @"Farkle.ParserResult`1". In the F# API, you can use the `|ParserSuccess|ParserError|` active pattern to match a parser result, or the `ParserResult.toResult` function to convert it to an F# `Result`.
 * The low-level tokenizer API has substantially changed, to the extent that migrating a tokenizer is tantamount to rewriting it. Due to a lack of known third-party uses, no specific guidance will be given. If you have a grammar using a custom tokenizer, you can take a look at the [tokenizer design document][tokenizer-design], or [a sample indent-based grammar][indent-based], to get an idea on how to write a custom tokenizer in Farkle 7.0.
 * The `Farkle.AST` type was removed.
 

--- a/docs/docs/migration/60-70.md
+++ b/docs/docs/migration/60-70.md
@@ -21,8 +21,8 @@ The following changes were made in Farkle 7.0 that might affect compatibility wi
 
 ### Changes to the builder API
 
-* The type `DesigntimeFarkle<T>` was split into two types; @"Farkle.Builder.IGrammarBuilder\`1" and @"Farkle.Builder.IGrammarSymbol\`1", where the latter inherits from the former. The untyped `DesigntimeFarkle` type got an equivalent treatment. Grammar builders cannot be used as members of a production, while grammar symbols can. This is used to enforce that customization options that apply to the whole grammar must be set at the top-most symbol that gets built.
-* The ability to rename symbols was removed. It had been introduced in Farkle 6 because the precompiler required a unique name for each precompiled grammar in an assembly. In Farkle 7.0, the precompiler was redesigned to not have this requirement, leaving no valid use cases for symbol renaming. If you want to set an informative name for the whole grammar, you can use the @"Farkle.Builder.GrammarBuilderExtensions.WithGrammarName" extension methods.
+* The type `DesigntimeFarkle<T>` was split into two types; @"Farkle.Builder.IGrammarBuilder`1" and @"Farkle.Builder.IGrammarSymbol`1", where the latter inherits from the former. The untyped `DesigntimeFarkle` type got an equivalent treatment. Grammar builders cannot be used as members of a production, while grammar symbols can. This is used to enforce that customization options that apply to the whole grammar must be set at the top-most symbol that gets built.
+* The ability to rename symbols was removed. It had been introduced in Farkle 6 because the precompiler required a unique name for each precompiled grammar in an assembly. In Farkle 7.0, the precompiler was redesigned to not have this requirement, leaving no valid use cases for symbol renaming. If you want to set an informative name for the whole grammar, you can use the @"Farkle.Builder.GrammarBuilderExtensions.WithGrammarName*" extension methods.
 * Grammars are case-sensitive by default. You can override this behavior by using the already existing @"Farkle.Builder.GrammarBuilderExtensions.CaseSensitive*" extension methods.
 * In grammars with the @"Farkle.Builder.Terminal.NewLine" symbol that have not disabled automatic whitespace handling, new lines in unexpected places are ignored by default and do not produce a syntax error. You can customize this behavior by using the newly introduced @"Farkle.Builder.GrammarBuilderExtensions.NewLineIsNoisy*" extension methods.
 * Each grammar can have up to one @"Farkle.Builder.OperatorPrecedence.OperatorScope", which must be set at the top-most symbol that gets built.
@@ -31,6 +31,9 @@ The following changes were made in Farkle 7.0 that might affect compatibility wi
 * In the F# API's `Terminals.stringEx` function, the `allowEscapeUnicode` parameter was removed. If you want to support escaping Unicode characters, include the `u` character in the `escapeChars` parameter.
 * @"Farkle.Builder.Regex.Any?displayProperty=nameWithType" was updated to match exactly any character, and no longer has lower priority than other character classes.
 * The `Farkle.Builder.PredefinedSets` type was removed. If you were using it, you have to specify the character set yourself.
+* In transformers, the first parameter has a type of @"Farkle.Parser.ParserState", and is passed by reference. This is not expected to cause any problems for F# due to its type inference, but in C#, the parameter declaration in the transformer lambda will be more verbose. If your transformer is `(_, data) => …`:
+  * Starting with C# 14, you can write it as `(ref _, data) => …`.
+  * However in earlier versions of C#, you have to write the types of both parameters, as `(ref ParserState _, ReadOnlySpan<char> data) => …`.
 
 #### Changes to the precompiler
 
@@ -54,6 +57,7 @@ The language of string regexes has been updated to be more in line with standard
 * Instead of an F# `Result`, the parser functions return values of type @"Farkle.ParserResult`1". In the F# API, you can use the `|ParserSuccess|ParserError|` active pattern to match a parser result, or the `ParserResult.toResult` function to convert it to an F# `Result`.
 * The low-level tokenizer API has substantially changed, to the extent that migrating a tokenizer is tantamount to rewriting it. Due to a lack of known third-party uses, no specific guidance will be given. If you have a grammar using a custom tokenizer, you can take a look at the [tokenizer design document][tokenizer-design], or [a sample indent-based grammar][indent-based], to get an idea on how to write a custom tokenizer in Farkle 7.0.
 * The `Farkle.AST` type was removed.
+* The `Farkle.Position` type was renamed to @"Farkle.TextPosition".
 
 ### Changes to the grammars API
 

--- a/docs/docs/migration/60-70.md
+++ b/docs/docs/migration/60-70.md
@@ -27,6 +27,7 @@ The following changes were made in Farkle 7.0 that might affect compatibility wi
 * Each grammar can have up to one @"Farkle.Builder.OperatorPrecedence.OperatorScope", which must be set at the top-most symbol that gets built.
 * In the F# API, fusers can have up to 6 parameters, instead of 16. If you need more parameters, you have to either refactor your grammar, or write the production with the C# API.
 * In the F# API's `Farkle.Builder.Terminals` module, the `genericSigned`, `genericUnsigned`, and `genericReal` functions are supported only when targeting a supported version of .NET. Using them when targeting earlier frameworks will result in a compile-time error.
+* In the F# API's `Terminals.stringEx` function, the `allowEscapeUnicode` parameter was removed. If you want to support escaping Unicode characters, include the `u` character in the `escapeChars` parameter.
 * @"Farkle.Builder.Regex.Any?displayProperty=nameWithType" was updated to match exactly any character, and no longer has lower priority than other character classes.
 * The `Farkle.Builder.PredefinedSets` type was removed. If you were using it, you have to specify the character set yourself.
 

--- a/src/Farkle/Builder/Terminals.cs
+++ b/src/Farkle/Builder/Terminals.cs
@@ -308,6 +308,11 @@ public static class Terminals
         ArgumentNullExceptionCompat.ThrowIfNull(escapeChars);
 
         bool allowEscapeUnicode = escapeChars.Contains('u');
+        ReadOnlySpan<Regex> escapeUnicode = allowEscapeUnicode ?
+            [Regex.Join(Regex.Literal('u'), Regex.OneOf(('0', '9'), ('a', 'f'), ('A', 'F')).Repeat(4))] :
+            [];
+        var escapeCharsSeq = allowEscapeUnicode ? escapeChars.Where(c => c != 'u') : escapeChars;
+
         var regexDelimiter = Regex.Literal(delimiter);
         var regexBackslash = Regex.Literal('\\');
         var regex =
@@ -317,17 +322,12 @@ public static class Terminals
                     Regex.NotOneOf(multiLine ? ['\n', '\r', '\\', delimiter] : ['\\', delimiter]),
                     Regex.Join(
                         regexBackslash,
-                        Regex.Choice(
+                        Regex.Choice([
                             regexBackslash,
                             regexDelimiter,
-                            Regex.OneOf(escapeChars.ToImmutableArray()),
-                            allowEscapeUnicode
-                                ? Regex.Join(
-                                    Regex.Literal('u'),
-                                    Regex.OneOf(('0', '9'), ('a', 'f'), ('A', 'F')).Repeat(4)
-                                )
-                                : Regex.Empty
-                        )
+                            Regex.OneOf(escapeCharsSeq.ToImmutableArray()),
+                            ..escapeUnicode
+                        ])
                     )
                 ).ZeroOrMore(),
                 regexDelimiter

--- a/src/Farkle/Builder/Terminals.cs
+++ b/src/Farkle/Builder/Terminals.cs
@@ -311,8 +311,6 @@ public static class Terminals
         ReadOnlySpan<Regex> escapeUnicode = allowEscapeUnicode ?
             [Regex.Join(Regex.Literal('u'), Regex.OneOf(('0', '9'), ('a', 'f'), ('A', 'F')).Repeat(4))] :
             [];
-        var escapeCharsSeq = allowEscapeUnicode ? escapeChars.Where(c => c != 'u') : escapeChars;
-
         var regexDelimiter = Regex.Literal(delimiter);
         var regexBackslash = Regex.Literal('\\');
         var regex =
@@ -325,7 +323,7 @@ public static class Terminals
                         Regex.Choice([
                             regexBackslash,
                             regexDelimiter,
-                            Regex.OneOf(escapeCharsSeq.ToImmutableArray()),
+                            Regex.OneOf(escapeChars.Where(c => c != 'u')),
                             ..escapeUnicode
                         ])
                     )

--- a/src/Farkle/Farkle.fs
+++ b/src/Farkle/Farkle.fs
@@ -653,6 +653,36 @@ module internal Terminals =
     /// Creates a terminal that matches a decimal number.
     let inline decimal name = Terminals.Decimal name
 
+#if NET8_0_OR_GREATER // .NET 7 technically, but the NuGet package has binaries for .NET 8+; targeting an earlier .NET version will fall back to .NET Standard binaries.
+    /// Creates a terminal that matches an unsigned integer, and parses it to the given type.
+    [<RequiresExplicitTypeArguments>]
+    let inline genericUnsigned<'T when Numerics.INumberBase<'T>> name = Terminals.UnsignedInteger<'T> name
+
+    /// Creates a terminal that matches a signed integer, and parses it to the given type.
+    [<RequiresExplicitTypeArguments>]
+    let inline genericSigned<'T when Numerics.ISignedNumber<'T>> name = Terminals.SignedInteger<'T> name
+
+    /// Creates a terminal that matches a floating-point number, and parses it to the given type.
+    /// A leading sign can be optionally allowed.
+    [<RequiresExplicitTypeArguments>]
+    let inline genericReal<'T when Numerics.IFloatingPoint<'T>> allowSign name =
+        if allowSign then
+            Terminals.SignedFloat<'T> name
+        else
+            Terminals.UnsignedFloat<'T> name
+#else
+    [<Obsolete("This function is not supported by this target framework.", true); RequiresExplicitTypeArguments>]
+    let inline genericUnsigned<'T> (name: string) = ignore name; raise <| PlatformNotSupportedException() :> IGrammarSymbol<'T>
+
+    [<Obsolete("This function is not supported by this target framework.", true); RequiresExplicitTypeArguments>]
+    let inline genericSigned<'T> (name: string) = ignore name; raise <| PlatformNotSupportedException() :> IGrammarSymbol<'T>
+
+    [<Obsolete("This function is not supported by this target framework.", true); RequiresExplicitTypeArguments>]
+    let inline genericReal<'T> (allowSign: bool) (name: string) =
+        ignore (allowSign, name)
+        raise <| PlatformNotSupportedException() :> IGrammarSymbol<'T>
+#endif
+
     /// Creates a terminal that matches a single-line C-like string.
     /// See `Terminals.String` for more information.
     let inline string delim name = Terminals.String(name, delim)

--- a/src/Farkle/Obsoletions.cs
+++ b/src/Farkle/Obsoletions.cs
@@ -5,7 +5,7 @@ namespace Farkle;
 
 internal static class Obsoletions
 {
-    public const string SharedUrlFormat = "https://github.com/teo-tsirpanis/Farkle/blob/mainstream/docs/diagnostics/{0}.md";
+    public const string SharedUrlFormat = "https://farkle.dev/diagnostics/{0}.html";
 
     public const string AsIsApiCode = "FARKLE1001";
     public const string AsIsApiMessage = "Use AsProduction() instead.";


### PR DESCRIPTION
This PR updates the migration guide and the F# API, based on learnings with trying to update third-party projects using Farkle. It also fixes a bug in `Terminals.String`.