### PR TITLE
Generate API reference from .NET 10.

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -11,7 +11,7 @@
                 }
             ],
             "properties": {
-                "TargetFramework": "net9.0"
+                "TargetFramework": "net10.0"
             },
             "output": "api",
             "disableGitFeatures": false,


### PR DESCRIPTION
We no longer build Farkle on .NET 9, which caused building docs to fail. This should fix it.