### PR TITLE
Revert "Bump Microsoft.Testing.Extensions.CodeCoverage from 17.14.2 to 18.0.4"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.9.1" />
     <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.4" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.VSTestBridge" Version="1.8.4" />
     <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="1.8.4" />
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.3.59" />


### PR DESCRIPTION
Reverts teo-tsirpanis/Farkle#443

Accidentally auto-merged while CI was failing.