### PR TITLE
Always use `CultureInfo.CurrentUICulture` to display localized text.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 #### 7.0.0-preview.3
 The following changes were made after 7.0.0-preview.2:
 * __Breaking change:__ The type `BuilderArtifacts` was renamed to `BuilderOutputs`.
+* Displaying localized text always uses the language specified in `CultureInfo.CurrentUICulture`. Previously, it used the `IFormatProvider` argument if specified, which could lead to inconsistencies, particularly when `CurrentCulture` and `CurrentUICulture` are different.
 
 #### 7.0.0-preview.2 - 30-10-2025
 The following changes were made after 7.0.0-preview.1:

--- a/src/Farkle/Diagnostics/Builder/BuilderDiagnostic.cs
+++ b/src/Farkle/Diagnostics/Builder/BuilderDiagnostic.cs
@@ -43,8 +43,8 @@ public readonly struct BuilderDiagnostic : IFormattable
     {
         string severity = Severity switch
         {
-            DiagnosticSeverity.Warning => Resources.GetResourceString(nameof(Resources.Warning), formatProvider),
-            DiagnosticSeverity.Error => Resources.GetResourceString(nameof(Resources.Error), formatProvider),
+            DiagnosticSeverity.Warning => Resources.Warning,
+            DiagnosticSeverity.Error => Resources.Error,
             _ => ""
         };
         string severityPadding = severity.Length > 0 ? " " : "";

--- a/src/Farkle/Diagnostics/Builder/BuilderSymbolName.cs
+++ b/src/Farkle/Diagnostics/Builder/BuilderSymbolName.cs
@@ -37,10 +37,10 @@ internal readonly struct BuilderSymbolName(string Name, TokenSymbolKind Kind, bo
     {
         return kind switch
         {
-            TokenSymbolKind.Terminal => Resources.GetResourceString(nameof(Resources.Builder_SymbolKind_Terminal), formatProvider, "terminal"),
-            TokenSymbolKind.Noise => Resources.GetResourceString(nameof(Resources.Builder_SymbolKind_Noise), formatProvider, "noise"),
-            TokenSymbolKind.GroupStart => Resources.GetResourceString(nameof(Resources.Builder_SymbolKind_GroupStart), formatProvider, "group start"),
-            TokenSymbolKind.GroupEnd => Resources.GetResourceString(nameof(Resources.Builder_SymbolKind_GroupEnd), formatProvider, "group end"),
+            TokenSymbolKind.Terminal => Resources.GetResourceString(nameof(Resources.Builder_SymbolKind_Terminal), "terminal"),
+            TokenSymbolKind.Noise => Resources.GetResourceString(nameof(Resources.Builder_SymbolKind_Noise), "noise"),
+            TokenSymbolKind.GroupStart => Resources.GetResourceString(nameof(Resources.Builder_SymbolKind_GroupStart), "group start"),
+            TokenSymbolKind.GroupEnd => Resources.GetResourceString(nameof(Resources.Builder_SymbolKind_GroupEnd), "group end"),
             _ => throw new ArgumentOutOfRangeException(nameof(kind))
         };
     }

--- a/src/Farkle/Diagnostics/Builder/LrConflict.cs
+++ b/src/Farkle/Diagnostics/Builder/LrConflict.cs
@@ -41,7 +41,7 @@ public sealed class LrConflict : IFormattable
 
     private string GetTerminalNameLocalized(IFormatProvider? provider) => TerminalOrEndOfInput.HasValue
         ? Grammar.GetTokenSymbol(TerminalOrEndOfInput).ToString()
-        : Resources.GetEofString(provider);
+        : Resources.Parser_Eof;
 
     private LrConflict() { }
 

--- a/src/Farkle/Diagnostics/LexicalError.cs
+++ b/src/Farkle/Diagnostics/LexicalError.cs
@@ -57,21 +57,19 @@ public sealed class LexicalError : IFormattable, IParserStateInfoSupplier
 
     private string ToString(IFormatProvider? formatProvider)
     {
-        string eofString = Resources.GetEofString(formatProvider);
         return Resources.Format(formatProvider,
             nameof(Resources.Parser_UnrecognizedToken),
             TokenText,
-            new DelimitedString(ExpectedTokenNames, ", ", eofString, TokenSymbol.FormatName));
+            new DelimitedString(ExpectedTokenNames, ", ", Resources.Parser_Eof, TokenSymbol.FormatName));
     }
 
 #if NET8_0_OR_GREATER
     bool ISpanFormattable.TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        string eofString = Resources.GetEofString(provider);
         return Resources.TryWrite(destination, provider,
             nameof(Resources.Parser_UnrecognizedToken), out charsWritten,
             TokenText,
-            new DelimitedString(ExpectedTokenNames, ", ", eofString, TokenSymbol.FormatName));
+            new DelimitedString(ExpectedTokenNames, ", ", Resources.Parser_Eof, TokenSymbol.FormatName));
     }
 #endif
 

--- a/src/Farkle/Diagnostics/LocalizedDiagnostic.cs
+++ b/src/Farkle/Diagnostics/LocalizedDiagnostic.cs
@@ -13,7 +13,7 @@ internal static class LocalizedDiagnostic
     // is a static string.
     {
         string IFormattable.ToString(string? format, IFormatProvider? formatProvider) =>
-            Resources.GetResourceString(resourceKey, formatProvider);
+            Resources.GetResourceString(resourceKey);
 
         public override string ToString() =>
             Resources.GetResourceString(resourceKey);

--- a/src/Farkle/Diagnostics/SyntaxError.cs
+++ b/src/Farkle/Diagnostics/SyntaxError.cs
@@ -58,7 +58,7 @@ public sealed class SyntaxError : IFormattable
 
     private string ToString(IFormatProvider? formatProvider)
     {
-        string eofString = Resources.GetEofString(formatProvider);
+        string eofString = Resources.Parser_Eof;
         return Resources.Format(formatProvider,
             nameof(Resources.Parser_UnexpectedToken),
             ActualTokenName ?? eofString,
@@ -68,7 +68,7 @@ public sealed class SyntaxError : IFormattable
 #if NET8_0_OR_GREATER
     bool ISpanFormattable.TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        string eofString = Resources.GetEofString(provider);
+        string eofString = Resources.Parser_Eof;
         return Resources.TryWrite(destination, provider,
             nameof(Resources.Parser_UnexpectedToken), out charsWritten,
             ActualTokenName ?? eofString,

--- a/src/Farkle/Properties/Resources.cs
+++ b/src/Farkle/Properties/Resources.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Resources;
 #if NET8_0_OR_GREATER
 using System.Runtime.CompilerServices;
@@ -27,14 +26,14 @@ internal static class Resources
     // when the application is being trimmed.
     internal static bool UsingResourceKeys() => s_usingResourceKeys;
 
-    public static string GetResourceString(string resourceKey, IFormatProvider? formatProvider = null, string? defaultValue = null)
+    public static string GetResourceString(string resourceKey, string? defaultValue = null)
     {
         if (UsingResourceKeys())
         {
             return defaultValue ?? resourceKey;
         }
 
-        return ResourceManager.GetString(resourceKey, formatProvider as CultureInfo)!;
+        return ResourceManager.GetString(resourceKey)!;
     }
 
 #if NET8_0_OR_GREATER
@@ -53,7 +52,7 @@ internal static class Resources
             return destination.TryWrite(formatProvider, $"{resourceKey}, {arg}", out charsWritten);
         }
 
-        string msg = ResourceManager.GetString(resourceKey, culture: formatProvider as CultureInfo)!;
+        string msg = ResourceManager.GetString(resourceKey)!;
         return destination.TryWrite(formatProvider, GetCompositeFormat(msg), out charsWritten, arg);
     }
 
@@ -64,7 +63,7 @@ internal static class Resources
             return destination.TryWrite(formatProvider, $"{resourceKey}, {arg1}, {arg2}", out charsWritten);
         }
 
-        string msg = ResourceManager.GetString(resourceKey, culture: formatProvider as CultureInfo)!;
+        string msg = ResourceManager.GetString(resourceKey)!;
         return destination.TryWrite(formatProvider, GetCompositeFormat(msg), out charsWritten, arg1, arg2);
     }
 
@@ -75,7 +74,7 @@ internal static class Resources
             return destination.TryWrite(formatProvider, $"{resourceKey}, {arg1}, {arg2}, {arg3}", out charsWritten);
         }
 
-        string msg = ResourceManager.GetString(resourceKey, culture: formatProvider as CultureInfo)!;
+        string msg = ResourceManager.GetString(resourceKey)!;
         return destination.TryWrite(formatProvider, GetCompositeFormat(msg), out charsWritten, arg1, arg2, arg3);
     }
 
@@ -97,7 +96,7 @@ internal static class Resources
             return destination.TryWrite(ref handler, out charsWritten);
         }
 
-        string msg = ResourceManager.GetString(resourceKey, culture: formatProvider as CultureInfo)!;
+        string msg = ResourceManager.GetString(resourceKey)!;
         return destination.TryWrite(formatProvider, GetCompositeFormat(msg), out charsWritten, args);
     }
 
@@ -116,7 +115,7 @@ internal static class Resources
 #endif
         }
 
-        string msg = ResourceManager.GetString(resourceKey, culture: formatProvider as CultureInfo)!;
+        string msg = ResourceManager.GetString(resourceKey)!;
         return string.Format(formatProvider, GetCompositeFormat(msg), arg);
     }
 
@@ -131,7 +130,7 @@ internal static class Resources
 #endif
         }
 
-        string msg = ResourceManager.GetString(resourceKey, culture: formatProvider as CultureInfo)!;
+        string msg = ResourceManager.GetString(resourceKey)!;
         return string.Format(formatProvider, GetCompositeFormat(msg), arg1, arg2);
     }
 
@@ -146,7 +145,7 @@ internal static class Resources
 #endif
         }
 
-        string msg = ResourceManager.GetString(resourceKey, culture: formatProvider as CultureInfo)!;
+        string msg = ResourceManager.GetString(resourceKey)!;
         return string.Format(formatProvider, GetCompositeFormat(msg), arg1, arg2, arg3);
     }
 
@@ -172,17 +171,8 @@ internal static class Resources
             return sb.ToString();
         }
 
-        string msg = ResourceManager.GetString(resourceKey, culture: formatProvider as CultureInfo)!;
+        string msg = ResourceManager.GetString(resourceKey)!;
         return string.Format(formatProvider, GetCompositeFormat(msg), args);
-    }
-
-    public static string GetEofString(IFormatProvider? formatProvider)
-    {
-        if (UsingResourceKeys())
-        {
-            return "(EOF)";
-        }
-        return GetResourceString(nameof(Parser_Eof), formatProvider);
     }
 
     public static string Grammar_TooNewFormat => GetResourceString(nameof(Grammar_TooNewFormat));
@@ -219,7 +209,7 @@ internal static class Resources
 
     public static string Parser_UnexpectedToken => GetResourceString(nameof(Parser_UnexpectedToken));
 
-    public static string Parser_Eof => GetResourceString(nameof(Parser_Eof));
+    public static string Parser_Eof => GetResourceString(nameof(Parser_Eof), "(EOF)");
 
     public static string Parser_UnparsableGrammar => GetResourceString(nameof(Parser_UnparsableGrammar));
 


### PR DESCRIPTION
It was not valid to use the `IFormatProvider` casted to `CultureInfo`, because it usually has the value of `CurrentCulture`, which can be different from `CurrentUICulture` (like in VS, if the computer is on a language not supported by VS).