### PR TITLE
Remove .NET Standard 2.1 support.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 #### 7.0.0-preview.3
 The following changes were made after 7.0.0-preview.2:
+* __Breaking change:__ Minimum target framework was increased from .NET Standard 2.1 to .NET 8, and will from now on follow the .NET support lifecycle.
 * __Breaking change:__ The type `BuilderArtifacts` was renamed to `BuilderOutputs`.
 * __Breaking change:__ The `ParserExtensions.ParseAsync` family of methods was updated to return a `Task<T>` instead of a `ValueTask<T>`. This change was made to avoid returning a potentially large value type, and align with the upcoming runtime async feature, after which `Task<T>` will be recommended in most cases.
 * __Breaking change:__ Multiple types in the `Farkle.Grammars` namespace were renamed to avoid collisions with types in the `Farkle.Builder` namespace. For example, `Farkle.Grammars.Nonterminal` was renamed to `Farkle.Grammars.NonterminalDefinition`.

--- a/docs/docs/migration/60-70.md
+++ b/docs/docs/migration/60-70.md
@@ -15,8 +15,7 @@ The following changes were made in Farkle 7.0 that might affect compatibility wi
 ### General changes
 
 * Farkle was rewritten in C#. F# remains a supported language, and the F# API is provided through a source file automatically included by the NuGet package.
-* Support for .NET Standard 2.0 was removed, and the minimum target framework was increased to .NET Standard 2.1. This is expected to change when [Unity adds support for CoreCLR][unity-coreclr], after which Farkle will target only .NET according to the [.NET support lifecycle][dotnet-support].
-  * Keeping .NET Standard 2.0 support for a little longer is a possibility, depending on ecosystem developments and community feedback. If you need to run Farkle on a .NET Standard 2.0-compatible framework, please open an issue.
+* Support for .NET Standard was removed, and the minimum target framework was increased to .NET 8, according to the [.NET support lifecycle][dotnet-support].
 * Instead of a discriminated union, parser and builder errors have a type of `object`, and can be converted to a human-readable message by calling `ToString()`. For certain error types carrying additional information, you can try casting the error object to one of the types defined in the @"Farkle.Diagnostics" namespace. There are some active patterns to help F# users.
 
 ### Changes to the builder API
@@ -159,7 +158,6 @@ let main _ =
   * The `productions_groupped` helper variable was removed; getting the productions of a nonterminal is now built-in, and available with the @"Farkle.Grammars.NonterminalDefinition.Productions?displayProperty=nameWithType" property.
 * The `fmt` function was removed.
 
-[unity-coreclr]: https://discussions.unity.com/t/coreclr-and-net-modernization-unite-2024/1519272
 [dotnet-support]: https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core
 [tokenizer-design]: https://github.com/teo-tsirpanis/Farkle/blob/mainstream/designs/7.0/tokenizer-api.md
 [indent-based]: https://github.com/teo-tsirpanis/Farkle/blob/mainstream/sample/Farkle.Samples.FSharp/IndentBased.fs

--- a/src/Farkle/Farkle.csproj
+++ b/src/Farkle/Farkle.csproj
@@ -2,7 +2,7 @@
   <Import Project="../NuGet.props" />
   <PropertyGroup>
     <!-- <TargetFrameworks>net10.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks> -->
-    <TargetFrameworks>net10.0;net8.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <LangVersion>14</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Following #428 which removed support for .NET Standard 2.0, this PR also removes support for .NET Standard 2.1.

The only reason support for .NET Standard 2.1 was kept was to support Unity, but Farkle on Unity has never been tested or requested, and it's unknown whether the precompiler would work with Unity's build system.

Farkle now targets .NET 8 at minimum, which will increase according to the .NET support lifecycle. This lets us remove most polyfills.