### PR TITLE
Performance improvements in the parser.

### DIFF
--- a/src/Farkle/Grammars/StateMachines/DfaWithoutConflicts.cs
+++ b/src/Farkle/Grammars/StateMachines/DfaWithoutConflicts.cs
@@ -17,6 +17,21 @@ internal unsafe sealed class DfaWithoutConflicts<TChar> : DfaImplementationBase<
     /// </remarks>
     private int[][]? _asciiLookup;
 
+    /// <summary>
+    /// A lookup table with the accept symbol for each state.
+    /// </summary>
+    /// <remarks>
+    /// The values are <see cref="TokenSymbolHandle.TableIndex"/> values.
+    /// A zero value means the state is not an accepting state.
+    /// This field is populated by <see cref="PrepareForParsing"/>.
+    /// </remarks>
+    // TODO-CODEGEN: Consider removing this optimization when codegen is implemented.
+    // Unlike the ASCII lookup, the accept symbols are already stored in an optimal way in the grammar file.
+    // Profiling has shown that this lookup table improves performance, but it still does not feel very right.
+    // After codegen is implemented, the grammar-based parsing logic will have less reasons to be super-optimized,
+    // so we can save some memory and switch back to reading the accept symbols directly from the grammar file.
+    private TokenSymbolHandle[]? _acceptSymbolLookup;
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static char CastChar(TChar c)
     {
@@ -123,8 +138,9 @@ internal unsafe sealed class DfaWithoutConflicts<TChar> : DfaImplementationBase<
     {
         // PrepareForParsing must have been called before this method.
         Debug.Assert(_asciiLookup is not null);
+        Debug.Assert(_acceptSymbolLookup is not null);
 
-        TokenSymbolHandle acceptSymbol = ReadAcceptSymbol(grammarFile, startState);
+        TokenSymbolHandle acceptSymbol = _acceptSymbolLookup[startState];
         int acceptSymbolLength = 0;
         int acceptSymbolState = startState;
 
@@ -142,7 +158,7 @@ internal unsafe sealed class DfaWithoutConflicts<TChar> : DfaImplementationBase<
             {
                 ignoreLeadingErrors = false;
                 currentState = nextState;
-                if (ReadAcceptSymbol(grammarFile, currentState) is { HasValue: true } s)
+                if (_acceptSymbolLookup[currentState] is { HasValue: true } s)
                 {
                     acceptSymbol = s;
                     acceptSymbolLength = i + 1;
@@ -180,6 +196,7 @@ internal unsafe sealed class DfaWithoutConflicts<TChar> : DfaImplementationBase<
     internal void PrepareForParsing()
     {
         _asciiLookup = CreateAsciiLookup();
+        _acceptSymbolLookup = CreateAcceptSymbolLookup();
     }
 
     internal override void ValidateContent(ReadOnlySpan<byte> grammarFile, in GrammarTables grammarTables)
@@ -197,6 +214,17 @@ internal unsafe sealed class DfaWithoutConflicts<TChar> : DfaImplementationBase<
     }
 
     internal override bool StateHasConflicts(int state) => false;
+
+    private TokenSymbolHandle[] CreateAcceptSymbolLookup()
+    {
+        var acceptSymbols = new TokenSymbolHandle[Count];
+        ReadOnlySpan<byte> grammarFile = Grammar.GrammarFile;
+        for (int i = 0; i < acceptSymbols.Length; i++)
+        {
+            acceptSymbols[i] = ReadAcceptSymbol(grammarFile, i);
+        }
+        return acceptSymbols;
+    }
 
     private int[][] CreateAsciiLookup()
     {

--- a/src/Farkle/TextPosition.cs
+++ b/src/Farkle/TextPosition.cs
@@ -60,7 +60,21 @@ public readonly struct TextPosition : IEquatable<TextPosition>
     public static TextPosition Create1(int line, int column) =>
         Create0(line - 1, column - 1);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal TextPosition AdvanceCore<T>(ReadOnlySpan<T> span, T cr, T lf)
+        where T : struct, IEquatable<T>
+    {
+        // Fast path: most tokens (identifiers, keywords, punctuation, numbers)
+        // contain no newlines. Avoid the loop and Create0 validation overhead.
+        int nlPos = span.IndexOfAny(lf, cr);
+        if (nlPos < 0)
+        {
+            return new(_line, _column + span.Length);
+        }
+        return AdvanceCoreSlow(span, cr, lf, nlPos);
+    }
+
+    private TextPosition AdvanceCoreSlow<T>(ReadOnlySpan<T> span, T cr, T lf, int nlPos)
         where T : struct, IEquatable<T>
     {
         // We advance the line number if:
@@ -68,43 +82,40 @@ public readonly struct TextPosition : IEquatable<TextPosition>
         // 2. We found an LF.
         // 3. We found a CRLF sequence.
         int line = _line, column = _column;
-        while (true)
+        do
         {
-            switch (span.IndexOfAny(lf, cr))
+            // CR or LF found.
+            bool foundCr = span[nlPos].Equals(cr);
+            // If the character is a CR, and it is the last character in the span,
+            // advance the column number by the number of characters before it.
+            if (foundCr && nlPos == span.Length - 1)
             {
-                case -1:
-                    // No CR or LF found. Advance the column number by the remaining
-                    // characters and return.
-                    return Create0(line, column + span.Length);
-                case int nlPos:
-                    // CR or LF found.
-                    bool foundCr = span[nlPos].Equals(cr);
-                    // If the character is a CR, and it is the last character in the span,
-                    // advance the column number by the number of characters before it.
-                    if (foundCr && nlPos == span.Length - 1)
-                    {
-                        column += nlPos;
-                    }
-                    // Otherwise (LF or CR not at the end of the span), advance the line number.
-                    else
-                    {
-                        line++;
-                        column = 0;
-                    }
-                    // We will continue searching from the character after the CR or LF we found above.
-                    int nextChar = nlPos + 1;
-                    // But, if the character was a CR, it was not the last character in the span,
-                    // and the character after it is an LF, we will skip the LF; we have already
-                    // advanced the line number for the CRLF sequence.
-                    if (foundCr && nextChar < span.Length && span[nextChar].Equals(lf))
-                    {
-                        nextChar++;
-                    }
-                    // Slice the span to the remaining characters.
-                    span = span[nextChar..];
-                    break;
+                column += nlPos;
             }
+            // Otherwise (LF or CR not at the end of the span), advance the line number.
+            else
+            {
+                line++;
+                column = 0;
+            }
+            // We will continue searching from the character after the CR or LF we found above.
+            int nextChar = nlPos + 1;
+            // But, if the character was a CR, it was not the last character in the span,
+            // and the character after it is an LF, we will skip the LF; we have already
+            // advanced the line number for the CRLF sequence.
+            if (foundCr && nextChar < span.Length && span[nextChar].Equals(lf))
+            {
+                nextChar++;
+            }
+            // Slice the span to the remaining characters.
+            span = span[nextChar..];
+            nlPos = span.IndexOfAny(lf, cr);
         }
+        while (nlPos >= 0);
+
+        // No more CR or LF found. Advance the column number by the remaining
+        // characters and return.
+        return new(line, column + span.Length);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -120,7 +131,7 @@ public readonly struct TextPosition : IEquatable<TextPosition>
             return AdvanceCore(Utilities.BitCastSpan<T, byte>(span), (byte)'\r', (byte)'\n');
         }
         // For any other type, we will just advance the column number by the length of the span.
-        return Create0(_line, _column + span.Length);
+        return new(_line, _column + span.Length);
     }
 
     internal TextPosition NextLine() => new(_line + 1, 0);


### PR DESCRIPTION
* Added fast path in `TextPosition.Advance`, for the cases when the character buffer does not contain CR or LF.
* Added lookup table for DFA accept states.
  * I don't like this one very much, but benchmarks say it meaningfully improves performance.

Found by [GitHub Copilot profiler agent](https://learn.microsoft.com/en-us/visualstudio/profiling/profile-with-copilot-agent?view=visualstudio) using Claude Opus 4.6.