### PR TITLE
Remove DFA accept symbol lookup table.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ The following changes were made after 7.0.0-preview.2:
 * __Breaking change:__ Multiple types in the `Farkle.Grammars` namespace were renamed to avoid collisions with types in the `Farkle.Builder` namespace. For example, `Farkle.Grammars.Nonterminal` was renamed to `Farkle.Grammars.NonterminalDefinition`.
 * Added the [precompiler](https://farkle.dev/the-precompiler.html).
 * Displaying localized text always uses the language specified in `CultureInfo.CurrentUICulture`. Previously, it used the `IFormatProvider` argument if specified, which could lead to inconsistencies, particularly when `CurrentCulture` and `CurrentUICulture` are different.
+* Fixed bugs and improved performance.
 
 #### 7.0.0-preview.2 - 30-10-2025
 The following changes were made after 7.0.0-preview.1:

--- a/src/Farkle/Grammars/StateMachines/DfaImplementationBase.cs
+++ b/src/Farkle/Grammars/StateMachines/DfaImplementationBase.cs
@@ -61,12 +61,12 @@ internal abstract class DfaImplementationBase<TChar> : Dfa<TChar> where TChar : 
     protected TokenSymbolHandle ReadAcceptSymbol(ReadOnlySpan<byte> grammarFile, int index) =>
         new(grammarFile.ReadUIntVariableSize(AcceptBase + index * _tokenSymbolIndexSize, _tokenSymbolIndexSize));
 
-    private int GetDefaultTransitionUnsafe(ReadOnlySpan<byte> grammarFile, int state)
+    protected int GetDefaultTransitionUnsafe(ReadOnlySpan<byte> grammarFile, int state)
     {
         return ReadState(grammarFile, DefaultTransitionBase, state);
     }
 
-    private (int Offset, int Count) GetEdgeBoundsUnsafe(ReadOnlySpan<byte> grammarFile, int state)
+    protected (int Offset, int Count) GetEdgeBoundsUnsafe(ReadOnlySpan<byte> grammarFile, int state)
     {
         int edgeOffset = ReadFirstEdge(grammarFile, state);
         int nextEdgeOffset = state != Count - 1 ? ReadFirstEdge(grammarFile, state + 1) : _edgeCount;

--- a/src/Farkle/Grammars/StateMachines/DfaImplementationBase.cs
+++ b/src/Farkle/Grammars/StateMachines/DfaImplementationBase.cs
@@ -77,7 +77,7 @@ internal abstract class DfaImplementationBase<TChar> : Dfa<TChar> where TChar : 
     {
         TChar cFrom = StateMachineUtilities.Read<TChar>(grammarFile, RangeFromBase + index * sizeof(char));
         TChar cTo = StateMachineUtilities.Read<TChar>(grammarFile, RangeToBase + index * sizeof(char));
-        int target = ReadState(grammarFile, EdgeTargetBase, + index);
+        int target = ReadState(grammarFile, EdgeTargetBase, index);
 
         return new(cFrom, cTo, target);
     }

--- a/src/Farkle/Grammars/StateMachines/DfaWithoutConflicts.cs
+++ b/src/Farkle/Grammars/StateMachines/DfaWithoutConflicts.cs
@@ -17,22 +17,6 @@ internal unsafe sealed class DfaWithoutConflicts<TChar> : DfaImplementationBase<
     /// </remarks>
     private int[][]? _asciiLookup;
 
-    /// <summary>
-    /// A lookup table with the accept symbol for each state.
-    /// </summary>
-    /// <remarks>
-    /// The values are <see cref="TokenSymbolHandle.TableIndex"/> values.
-    /// A zero value means the state is not an accepting state.
-    /// This field is populated by <see cref="PrepareForParsing"/>.
-    /// </remarks>
-    // TODO-CODEGEN: Consider removing this optimization when codegen is implemented.
-    // Unlike the ASCII lookup, the accept symbols are already stored in an optimal way in the grammar file.
-    // Benchmarking has shown that this lookup table improves performance by around 18,8%, but it still does
-    // not feel very right.
-    // After codegen is implemented, the grammar-based parsing logic will have less reasons to be super-optimized,
-    // so we can save some memory and switch back to reading the accept symbols directly from the grammar file.
-    private TokenSymbolHandle[]? _acceptSymbolLookup;
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static char CastChar(TChar c)
     {
@@ -139,9 +123,8 @@ internal unsafe sealed class DfaWithoutConflicts<TChar> : DfaImplementationBase<
     {
         // PrepareForParsing must have been called before this method.
         Debug.Assert(_asciiLookup is not null);
-        Debug.Assert(_acceptSymbolLookup is not null);
 
-        TokenSymbolHandle acceptSymbol = _acceptSymbolLookup[startState];
+        TokenSymbolHandle acceptSymbol = GetAcceptSymbol(startState);
         int acceptSymbolLength = 0;
         int acceptSymbolState = startState;
 
@@ -159,7 +142,7 @@ internal unsafe sealed class DfaWithoutConflicts<TChar> : DfaImplementationBase<
             {
                 ignoreLeadingErrors = false;
                 currentState = nextState;
-                if (_acceptSymbolLookup[currentState] is { HasValue: true } s)
+                if (GetAcceptSymbol(currentState) is { HasValue: true } s)
                 {
                     acceptSymbol = s;
                     acceptSymbolLength = i + 1;
@@ -197,7 +180,6 @@ internal unsafe sealed class DfaWithoutConflicts<TChar> : DfaImplementationBase<
     internal void PrepareForParsing()
     {
         _asciiLookup = CreateAsciiLookup();
-        _acceptSymbolLookup = CreateAcceptSymbolLookup();
     }
 
     internal override void ValidateContent(ReadOnlySpan<byte> grammarFile, in GrammarTables grammarTables)
@@ -215,17 +197,6 @@ internal unsafe sealed class DfaWithoutConflicts<TChar> : DfaImplementationBase<
     }
 
     internal override bool StateHasConflicts(int state) => false;
-
-    private TokenSymbolHandle[] CreateAcceptSymbolLookup()
-    {
-        var acceptSymbols = new TokenSymbolHandle[Count];
-        ReadOnlySpan<byte> grammarFile = Grammar.GrammarFile;
-        for (int i = 0; i < acceptSymbols.Length; i++)
-        {
-            acceptSymbols[i] = ReadAcceptSymbol(grammarFile, i);
-        }
-        return acceptSymbols;
-    }
 
     private int[][] CreateAsciiLookup()
     {

--- a/src/Farkle/Grammars/StateMachines/DfaWithoutConflicts.cs
+++ b/src/Farkle/Grammars/StateMachines/DfaWithoutConflicts.cs
@@ -62,7 +62,7 @@ internal unsafe sealed class DfaWithoutConflicts<TChar> : DfaImplementationBase<
     {
         ValidateStateIndex(state);
 
-        if (GetAcceptSymbol(state).HasValue)
+        if (ReadAcceptSymbol(Grammar.GrammarFile, state).HasValue)
         {
             return (state, 1);
         }
@@ -70,12 +70,11 @@ internal unsafe sealed class DfaWithoutConflicts<TChar> : DfaImplementationBase<
         return (0, 0);
     }
 
-    internal override TokenSymbolHandle GetAcceptSymbolAt(int index) => GetAcceptSymbol(index);
-
-    private TokenSymbolHandle GetAcceptSymbol(int state)
+    internal override TokenSymbolHandle GetAcceptSymbolAt(int index)
     {
-        ValidateStateIndex(state);
-        return ReadAcceptSymbol(Grammar.GrammarFile, state);
+        ValidateStateIndex(index);
+
+        return ReadAcceptSymbol(Grammar.GrammarFile, index);
     }
 
     private int NextStateSlow(ReadOnlySpan<byte> grammarFile, int state, TChar c)
@@ -124,7 +123,7 @@ internal unsafe sealed class DfaWithoutConflicts<TChar> : DfaImplementationBase<
         // PrepareForParsing must have been called before this method.
         Debug.Assert(_asciiLookup is not null);
 
-        TokenSymbolHandle acceptSymbol = GetAcceptSymbol(startState);
+        TokenSymbolHandle acceptSymbol = ReadAcceptSymbol(grammarFile, startState);
         int acceptSymbolLength = 0;
         int acceptSymbolState = startState;
 
@@ -142,7 +141,7 @@ internal unsafe sealed class DfaWithoutConflicts<TChar> : DfaImplementationBase<
             {
                 ignoreLeadingErrors = false;
                 currentState = nextState;
-                if (GetAcceptSymbol(currentState) is { HasValue: true } s)
+                if (ReadAcceptSymbol(grammarFile, currentState) is { HasValue: true } s)
                 {
                     acceptSymbol = s;
                     acceptSymbolLength = i + 1;

--- a/src/Farkle/Grammars/StateMachines/DfaWithoutConflicts.cs
+++ b/src/Farkle/Grammars/StateMachines/DfaWithoutConflicts.cs
@@ -77,6 +77,11 @@ internal unsafe sealed class DfaWithoutConflicts<TChar> : DfaImplementationBase<
         return ReadAcceptSymbol(Grammar.GrammarFile, index);
     }
 
+    private bool StateHasEdges(ReadOnlySpan<byte> grammarFile, int state)
+    {
+        return GetEdgeBoundsUnsafe(grammarFile, state).Count > 0 || GetDefaultTransitionUnsafe(grammarFile, state) >= 0;
+    }
+
     private int NextStateSlow(ReadOnlySpan<byte> grammarFile, int state, TChar c)
     {
         int edgeOffset = ReadFirstEdge(grammarFile, state);
@@ -159,7 +164,7 @@ internal unsafe sealed class DfaWithoutConflicts<TChar> : DfaImplementationBase<
         // end of the input block. We cannot accept it, there could be more digits after it that
         // were not yet read. By contrast, if we had found `true` at the end of the block, we can
         // accept it, because there is no way for a longer token to be formed.
-        if (!(isFinal || this[currentState] is { Edges.Count: 0 } and { DefaultTransition: < 0 }))
+        if (!isFinal && StateHasEdges(grammarFile, currentState))
         {
             return DfaMatchResult.CreateNeedsMoreChars(acceptSymbol, acceptSymbolState, acceptSymbolLength);
         }


### PR DESCRIPTION
Local benchmarking has indicated that this might bring performance improvements similar to the accept symbol table (that Opus suggested and have never liked as an idea).