### PR TITLE
Have `GrammarWriter` implement `IGrammarSyntaxProvider`.

### DIFF
--- a/src/Farkle/Builder/GrammarBuild.cs
+++ b/src/Farkle/Builder/GrammarBuild.cs
@@ -295,6 +295,10 @@ internal static class GrammarBuild
             regexBuilder?.Add(Regex.Accept(regex, handle, lowestPriority: true));
         }
 
+        // Set grammar info.
+        NonterminalHandle startSymbol = (NonterminalHandle)symbolMap[grammarDefinition.StartSymbol];
+        writer.SetGrammarInfo(writer.GetOrAddString(grammarDefinition.GrammarName), startSymbol, grammarDefinition.Attributes);
+
         // Build state machines if they are requested.
         if (dfaSymbols is not null)
         {
@@ -329,13 +333,8 @@ internal static class GrammarBuild
             var conflictResolver = operatorScope is not null
                 ? new OperatorScopeConflictResolver(operatorScope, operatorSymbolMap!, literalsCaseInsensitive, log)
                 : null;
-            var syntaxProvider = new GrammarSyntaxProvider(grammarDefinition, productionMembers);
-            writer.AddStateMachine(LalrBuild.Build(syntaxProvider, conflictResolver, log, options.CancellationToken));
+            writer.AddStateMachine(LalrBuild.Build(writer, conflictResolver, log, options.CancellationToken));
         }
-
-        // Set grammar info.
-        NonterminalHandle startSymbol = (NonterminalHandle)symbolMap[grammarDefinition.StartSymbol];
-        writer.SetGrammarInfo(writer.GetOrAddString(grammarDefinition.GrammarName), startSymbol, grammarDefinition.Attributes);
 
         // Farkle's builder can be trusted to not produce malformed grammars, so we can skip content validation.
         // We still do it in DEBUG mode for testing coverage.
@@ -469,69 +468,6 @@ internal static class GrammarBuild
         {
             var (name, kind) = _symbolNames[symbol];
             return new(name, kind, ShouldDisambiguate(name));
-        }
-    }
-
-    private sealed class GrammarSyntaxProvider : IGrammarSyntaxProvider
-    {
-        private readonly GrammarDefinition _grammarDefinition;
-
-        private readonly (int FirstProduction, int ProductionCount)[] _nonterminalProductionBounds;
-
-        private readonly int[] _productionHeads;
-
-        private readonly (int FirstMember, int MemberCount)[] _productionMemberBounds;
-
-        private readonly List<EntityHandle> _productionMembers;
-
-        public GrammarSyntaxProvider(GrammarDefinition grammarDefinition, List<EntityHandle> productionMembers)
-        {
-            _grammarDefinition = grammarDefinition;
-            _nonterminalProductionBounds = new (int, int)[grammarDefinition.Nonterminals.Count];
-            _productionHeads = new int[grammarDefinition.Productions.Count];
-            _productionMemberBounds = new (int, int)[grammarDefinition.Productions.Count];
-            _productionMembers = productionMembers;
-
-            int productionIndex = 0;
-            for (int i = 0; i < _nonterminalProductionBounds.Length; i++)
-            {
-                int productionCount = _grammarDefinition.Nonterminals[i].FreezeAndGetProductions().Length;
-                _nonterminalProductionBounds[i] = (productionIndex, productionCount);
-                _productionHeads.AsSpan(productionIndex, productionCount).Fill(i);
-                productionIndex += productionCount;
-            }
-
-            int productionMemberIndex = 0;
-            for (int i = 0; i < _productionMemberBounds.Length; i++)
-            {
-                int memberCount = _grammarDefinition.Productions[i].Members.Length;
-                _productionMemberBounds[i] = (productionMemberIndex, memberCount);
-                productionMemberIndex += memberCount;
-            }
-        }
-
-        public int TerminalCount => _grammarDefinition.Terminals.Count;
-
-        public int NonterminalCount => _grammarDefinition.Nonterminals.Count;
-
-        public int ProductionCount => _grammarDefinition.Productions.Count;
-
-        public int StartSymbol => 0;
-
-        public string GetTerminalName(int index) => _grammarDefinition.Terminals[index].Name;
-
-        public string GetNonterminalName(int index) => _grammarDefinition.Nonterminals[index].Name;
-
-        public (int FirstProduction, int ProductionCount) GetNonterminalProductions(int index) => _nonterminalProductionBounds[index];
-
-        public int GetProductionHead(int index) => _productionHeads[index];
-
-        public (int FirstMember, int MemberCount) GetProductionMembers(int index) => _productionMemberBounds[index];
-
-        public (int SymbolIndex, bool IsTerminal) GetProductionMember(int index)
-        {
-            EntityHandle member = _productionMembers[index];
-            return ((int)(member.TableIndex - 1), member.Kind == TableKind.TokenSymbol);
         }
     }
 }

--- a/src/Farkle/Builder/GrammarBuild.cs
+++ b/src/Farkle/Builder/GrammarBuild.cs
@@ -244,15 +244,12 @@ internal static class GrammarBuild
         }
 
         // Add productions.
-        // Keep a flattened list of production members; it will be needed by the syntax provider.
-        List<EntityHandle> productionMembers = [];
         foreach (IProduction production in grammarDefinition.Productions)
         {
             ProductionHandle handle = writer.AddProduction(production.Members.Length);
             foreach (IGrammarSymbol member in production.Members)
             {
                 EntityHandle memberHandle = symbolMap[GrammarDefinition.GetSymbolIdentityObject(member.Symbol)];
-                productionMembers.Add(memberHandle);
                 writer.AddProductionMember(memberHandle);
             }
             operatorSymbolMap?.Add(handle, production);

--- a/src/Farkle/Builder/IGrammarSyntaxProvider.cs
+++ b/src/Farkle/Builder/IGrammarSyntaxProvider.cs
@@ -40,6 +40,7 @@ internal interface IGrammarSyntaxProvider
     /// </summary>
     int StartSymbol { get; }
 
+#if DEBUG
     /// <summary>
     /// Gets the name of a terminal.
     /// </summary>
@@ -57,6 +58,7 @@ internal interface IGrammarSyntaxProvider
     /// The nonterminal's name, without any quoting or formatting.
     /// </returns>
     string GetNonterminalName(int index);
+#endif
 
     /// <summary>
     /// Gets the indices of the productions that have a certain nonterminal at

--- a/src/Farkle/Builder/Lr/AugmentedSyntaxProvider.cs
+++ b/src/Farkle/Builder/Lr/AugmentedSyntaxProvider.cs
@@ -65,9 +65,11 @@ internal readonly struct AugmentedSyntaxProvider(IGrammarSyntaxProvider provider
 
     public ProductionCollection AllProductions => new(0, ProductionCount, this);
 
+#if DEBUG
     public string GetTerminalName(int index) => index == 0 ? "#" : _provider.GetTerminalName(index - 1);
 
     public string GetNonterminalName(int index) => index == 0 ? "S'" : _provider.GetNonterminalName(index - 1);
+#endif
 
     private (int FirstProduction, int ProductionCount) GetNonterminalProductions(int nonterminalIndex)
     {

--- a/src/Farkle/Grammars/GrammarTables.cs
+++ b/src/Farkle/Grammars/GrammarTables.cs
@@ -5,6 +5,7 @@ using Farkle.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using static Farkle.Grammars.GrammarUtilities;
 
@@ -548,7 +549,6 @@ internal readonly struct GrammarTables
                 previousFirstMember = firstMember;
                 ValidateHandle(firstMember, ProductionMemberRowCount + 1);
             }
-            Assert(currentHead == NonterminalRowCount);
         }
 
         for (uint i = 1; i <= (uint)ProductionMemberRowCount; i++)
@@ -586,7 +586,8 @@ internal readonly struct GrammarTables
             }
         }
 
-        static void Assert([DoesNotReturnIf(false)] bool condition, string? message = null)
+        [StackTraceHidden]
+        static void Assert([DoesNotReturnIf(false)] bool condition, [CallerArgumentExpression(nameof(condition))] string? message = null)
         {
             if (!condition)
             {

--- a/src/Farkle/Grammars/ProductionHandle.cs
+++ b/src/Farkle/Grammars/ProductionHandle.cs
@@ -20,6 +20,8 @@ public readonly struct ProductionHandle : IEquatable<ProductionHandle>
     internal uint TableIndex { get; }
     internal ProductionHandle(uint tableIndex) => TableIndex = tableIndex;
 
+    internal static ProductionHandle FromZeroBasedValue(int value) => new((uint)(value + 1));
+
     /// <summary>
     /// Gets the production's index in the grammar.
     /// </summary>

--- a/src/Farkle/Grammars/Writers/GrammarTablesWriter.cs
+++ b/src/Farkle/Grammars/Writers/GrammarTablesWriter.cs
@@ -49,7 +49,11 @@ internal struct GrammarTablesWriter
 
     public readonly int ProductionCount => _productions?.Count ?? 0;
 
+    public readonly int ProductionMemberCount => _productionMembers?.Count ?? 0;
+
     public readonly int GroupCount => _groups?.Count ?? 0;
+
+    public readonly NonterminalHandle StartSymbol => _grammarStartSymbol;
 
     public GrammarTablesWriter() { }
 
@@ -313,6 +317,32 @@ internal struct GrammarTablesWriter
         | (_productionMembers is { Count: > 0 } ? TableKinds.ProductionMember : 0)
         | (_stateMachines is { Count: > 0 } ? TableKinds.StateMachine : 0)
         | (_specialNames is { Count: > 0 } ? TableKinds.SpecialName : 0);
+
+    public readonly StringHandle GetTokenSymbolName(int index)
+    {
+        Debug.Assert(_tokenSymbols is not null);
+        return _tokenSymbols[index].Name;
+    }
+
+    public readonly (StringHandle Name, ProductionHandle FirstProduction) GetNonterminalInfo(int index)
+    {
+        Debug.Assert(_nonterminals is not null);
+        NonterminalRow row = _nonterminals[index];
+        return (row.Name, row.FirstProduction);
+    }
+
+    public readonly (NonterminalHandle Head, uint FirstMember) GetProductionInfo(int index)
+    {
+        Debug.Assert(_productions is not null);
+        ProductionRow row = _productions[index];
+        return (row.Head, row.FirstMember);
+    }
+
+    public readonly EntityHandle GetProductionMember(int index)
+    {
+        Debug.Assert(_productionMembers is not null);
+        return _productionMembers[index].Member;
+    }
 
     public readonly void WriteTo(IBufferWriter<byte> writer, GrammarHeapSizes heapSizes)
     {

--- a/src/Farkle/Grammars/Writers/GrammarTablesWriter.cs
+++ b/src/Farkle/Grammars/Writers/GrammarTablesWriter.cs
@@ -30,6 +30,7 @@ internal struct GrammarTablesWriter
 
     private List<ProductionRow>? _productions;
     private int _requiredProductions;
+    private uint _currentProductionHead = 1;
 
     private List<ProductionMemberRow>? _productionMembers;
     private int _requiredProductionMembers;
@@ -49,6 +50,8 @@ internal struct GrammarTablesWriter
     public readonly int ProductionCount => _productions?.Count ?? 0;
 
     public readonly int GroupCount => _groups?.Count ?? 0;
+
+    public GrammarTablesWriter() { }
 
     private static uint EncodeSymbolCodedIndex(EntityHandle handle)
     {
@@ -170,7 +173,7 @@ internal struct GrammarTablesWriter
 
         _pendingGroupStarts.Remove(start);
         var groups = _groups ??= new();
-        groups.Add(new() { Name = name, Container = container, Flags = flags, Start = start, End = end, NestingCount = nestingCount });
+        groups.Add(new() { Name = name, Container = container, Flags = flags, Start = start, End = end, FirstNesting = (uint)(_requiredGroupNestings + 1) });
         if (nestingCount > 0)
         {
             _groupNestings ??= new();
@@ -199,7 +202,8 @@ internal struct GrammarTablesWriter
         ArgumentOutOfRangeException.ThrowIfNegative(productionCount);
 
         var nonterminals = _nonterminals ??= new();
-        nonterminals.Add(new() { Name = name, Flags = flags, ProductionCount = productionCount });
+        var firstProduction = ProductionHandle.FromZeroBasedValue(_requiredProductions);
+        nonterminals.Add(new() { Name = name, Flags = flags, FirstProduction = firstProduction });
         if (productionCount > 0)
         {
             _productions ??= new();
@@ -214,17 +218,22 @@ internal struct GrammarTablesWriter
         ArgumentOutOfRangeException.ThrowIfNegative(memberCount);
 
         var productions = _productions;
-        if (productions is not { Count: int count } || count >= _requiredProductions)
+        if (productions is not { Count: int count } || count >= _requiredProductions || _nonterminals is not { Count: > 0 })
         {
             ThrowHelpers.ThrowInvalidOperationException("Cannot add more productions; please add a nonterminal first.");
         }
+        Debug.Assert(_nonterminals is not null); // Is implied by productions not being null.
 
-        productions.Add(new() { MemberCount = memberCount });
+        productions.Add(new() { Head = new(_currentProductionHead), FirstMember = (uint)(_requiredProductionMembers + 1) });
         if (memberCount > 0)
         {
             _productionMembers ??= new();
         }
         _requiredProductionMembers += memberCount;
+        while (_currentProductionHead < _nonterminals.Count && _nonterminals[(int)_currentProductionHead].FirstProduction.TableIndex - 1 <= productions.Count)
+        {
+            _currentProductionHead++;
+        }
         return new((uint)productions.Count);
     }
 
@@ -383,7 +392,6 @@ internal struct GrammarTablesWriter
 
         if (_groups is not null)
         {
-            uint firstNesting = 1;
             foreach (var row in _groups)
             {
                 WriteStringHandle(row.Name);
@@ -391,8 +399,7 @@ internal struct GrammarTablesWriter
                 writer.Write((ushort)row.Flags);
                 writer.WriteVariableSize(row.Start.TableIndex, tokenSymbolIndexSize);
                 writer.WriteVariableSize(row.End.TableIndex, tokenSymbolIndexSize);
-                writer.WriteVariableSize(firstNesting, groupNestingIndexSize);
-                firstNesting += (uint)row.NestingCount;
+                writer.WriteVariableSize(row.FirstNesting, groupNestingIndexSize);
             }
         }
 
@@ -406,13 +413,11 @@ internal struct GrammarTablesWriter
 
         if (_nonterminals is not null)
         {
-            uint firstProduction = 1;
             foreach (var row in _nonterminals)
             {
                 WriteStringHandle(row.Name);
                 writer.Write((ushort)row.Flags);
-                writer.WriteVariableSize(firstProduction, productionIndexSize);
-                firstProduction += (uint)row.ProductionCount;
+                writer.WriteVariableSize(row.FirstProduction.TableIndex, productionIndexSize);
             }
         }
 
@@ -421,33 +426,10 @@ internal struct GrammarTablesWriter
             List<NonterminalRow>? nonterminals = _nonterminals;
             Debug.Assert(nonterminals is not null);
 
-            int currentNonterminal = 0;
-            int remainingProductions = nonterminals[currentNonterminal].ProductionCount;
-            UpdateRemainingProductions();
-
-            uint firstMember = 1;
             foreach (var row in _productions)
             {
-                // currentNonterminal is zero-based, we have to increment it by one to write it.
-                writer.WriteVariableSize((uint)currentNonterminal + 1, nonterminalIndexSize);
-                writer.WriteVariableSize(firstMember, productionMemberIndexSize);
-                firstMember += (uint)row.MemberCount;
-                remainingProductions--;
-                UpdateRemainingProductions();
-            }
-            Debug.Assert(remainingProductions == 0 && currentNonterminal == nonterminals.Count - 1);
-
-            // We track the head nonterminal by counting how many productions we have written
-            // and how many productions are left in the current nonterminal. When we have finished
-            // writing all productions for the current nonterminal, we move to the next nonterminal,
-            // while skipping those with no productions.
-            void UpdateRemainingProductions()
-            {
-                while (remainingProductions == 0 && currentNonterminal < nonterminals.Count - 1)
-                {
-                    currentNonterminal++;
-                    remainingProductions = nonterminals[currentNonterminal].ProductionCount;
-                }
+                writer.WriteVariableSize(row.Head.TableIndex, nonterminalIndexSize);
+                writer.WriteVariableSize(row.FirstMember, productionMemberIndexSize);
             }
         }
 
@@ -513,7 +495,7 @@ internal struct GrammarTablesWriter
         public required GroupAttributes Flags { get; init; }
         public required TokenSymbolHandle Start { get; init; }
         public required TokenSymbolHandle End { get; init; }
-        public required int NestingCount { get; init; }
+        public required uint FirstNesting { get; init; }
     }
 
     private readonly struct GroupNestingRow
@@ -525,12 +507,13 @@ internal struct GrammarTablesWriter
     {
         public required StringHandle Name { get; init; }
         public required NonterminalAttributes Flags { get; init; }
-        public required int ProductionCount { get; init; }
+        public required ProductionHandle FirstProduction { get; init; }
     }
 
     private readonly struct ProductionRow
     {
-        public required int MemberCount { get; init; }
+        public required NonterminalHandle Head { get; init; }
+        public required uint FirstMember { get; init; }
     }
 
     private readonly struct ProductionMemberRow

--- a/src/Farkle/Grammars/Writers/GrammarTablesWriter.cs
+++ b/src/Farkle/Grammars/Writers/GrammarTablesWriter.cs
@@ -454,9 +454,6 @@ internal struct GrammarTablesWriter
 
         if (_productions is not null)
         {
-            List<NonterminalRow>? nonterminals = _nonterminals;
-            Debug.Assert(nonterminals is not null);
-
             foreach (var row in _productions)
             {
                 writer.WriteVariableSize(row.Head.TableIndex, nonterminalIndexSize);

--- a/src/Farkle/Grammars/Writers/GrammarTablesWriter.cs
+++ b/src/Farkle/Grammars/Writers/GrammarTablesWriter.cs
@@ -228,16 +228,17 @@ internal struct GrammarTablesWriter
         }
         Debug.Assert(_nonterminals is not null); // Is implied by productions not being null.
 
+        while (_currentProductionHead < _nonterminals.Count && _nonterminals[(int)_currentProductionHead].FirstProduction.TableIndex - 1 <= productions.Count)
+        {
+            _currentProductionHead++;
+        }
+
         productions.Add(new() { Head = new(_currentProductionHead), FirstMember = (uint)(_requiredProductionMembers + 1) });
         if (memberCount > 0)
         {
             _productionMembers ??= new();
         }
         _requiredProductionMembers += memberCount;
-        while (_currentProductionHead < _nonterminals.Count && _nonterminals[(int)_currentProductionHead].FirstProduction.TableIndex - 1 <= productions.Count)
-        {
-            _currentProductionHead++;
-        }
         return new((uint)productions.Count);
     }
 

--- a/src/Farkle/Grammars/Writers/GrammarWriter.cs
+++ b/src/Farkle/Grammars/Writers/GrammarWriter.cs
@@ -2,18 +2,23 @@
 // SPDX-License-Identifier: MIT
 
 using Farkle.Buffers;
+using Farkle.Builder;
 using System.Buffers;
 using System.Collections.Immutable;
 
 namespace Farkle.Grammars.Writers;
 
-internal sealed class GrammarWriter
+internal sealed class GrammarWriter : IGrammarSyntaxProvider
 {
     private StringHeapWriter _stringHeapWriter = new();
 
     private BlobHeapWriter _blobHeapWriter = new();
 
     private GrammarTablesWriter _tablesWriter = new();
+
+#if DEBUG
+    private readonly Dictionary<StringHandle, string> _stringReverseLookup = new() { [default] = "" };
+#endif
 
     private static void ValidateTableIndex(uint tableIndex, string paramName)
     {
@@ -32,11 +37,23 @@ internal sealed class GrammarWriter
 
     public int TokenSymbolCount => _tablesWriter.TokenSymbolRowCount;
 
+    int IGrammarSyntaxProvider.TerminalCount => _tablesWriter.TerminalCount;
+
+    int IGrammarSyntaxProvider.NonterminalCount => _tablesWriter.NonterminalCount;
+
+    int IGrammarSyntaxProvider.ProductionCount => _tablesWriter.ProductionCount;
+
+    int IGrammarSyntaxProvider.StartSymbol => _tablesWriter.StartSymbol.Value;
+
     public StringHandle GetOrAddString(string str)
     {
         ArgumentNullException.ThrowIfNull(str);
 
-        return _stringHeapWriter.Add(str);
+        var handle = _stringHeapWriter.Add(str);
+#if DEBUG
+        _ = _stringReverseLookup.TryAdd(handle, str);
+#endif
+        return handle;
     }
 
     public BlobHandle GetOrAddBlob(PooledSegmentBufferWriter<byte> blob) =>
@@ -197,5 +214,33 @@ internal sealed class GrammarWriter
         using var buffer = new PooledSegmentBufferWriter<byte>();
         WriteTo(buffer);
         return buffer.ToImmutableArray();
+    }
+
+#if DEBUG
+    string IGrammarSyntaxProvider.GetTerminalName(int index) => _stringReverseLookup[_tablesWriter.GetTokenSymbolName(index)];
+
+    string IGrammarSyntaxProvider.GetNonterminalName(int index) => _stringReverseLookup[_tablesWriter.GetNonterminalInfo(index).Name];
+#endif
+
+    (int FirstProduction, int ProductionCount) IGrammarSyntaxProvider.GetNonterminalProductions(int index)
+    {
+        int firstProduction = _tablesWriter.GetNonterminalInfo(index).FirstProduction.Value;
+        int firstProductionOfNext = index == _tablesWriter.NonterminalCount - 1 ? _tablesWriter.ProductionCount : _tablesWriter.GetNonterminalInfo(index + 1).FirstProduction.Value;
+        return (firstProduction, firstProductionOfNext - firstProduction);
+    }
+
+    int IGrammarSyntaxProvider.GetProductionHead(int index) => _tablesWriter.GetProductionInfo(index).Head.Value;
+
+    (int FirstMember, int MemberCount) IGrammarSyntaxProvider.GetProductionMembers(int index)
+    {
+        int firstMember = (int)(_tablesWriter.GetProductionInfo(index).FirstMember - 1);
+        int firstMemberOfNext = index == _tablesWriter.ProductionCount - 1 ? _tablesWriter.ProductionMemberCount : (int)(_tablesWriter.GetProductionInfo(index + 1).FirstMember - 1);
+        return (firstMember, firstMemberOfNext - firstMember);
+    }
+
+    (int SymbolIndex, bool IsTerminal) IGrammarSyntaxProvider.GetProductionMember(int index)
+    {
+        var member = _tablesWriter.GetProductionMember(index);
+        return ((int)(member.TableIndex - 1), member.IsTokenSymbol);
     }
 }

--- a/tests/Farkle.Tests.CSharp/GrammarTablesTests.cs
+++ b/tests/Farkle.Tests.CSharp/GrammarTablesTests.cs
@@ -66,4 +66,31 @@ internal class GrammarTablesTests
         // We can add up to 2^20 - 1 token symbols.
         Assert.That(() => writer.AddTokenSymbol(DummyStringHandle, TokenSymbolAttributes.None), Throws.InvalidOperationException);
     }
+
+    [Test]
+    public void TestNonterminalsWithNoProductions()
+    {
+        var writer = new GrammarTablesWriter();
+        using var buffer = new PooledSegmentBufferWriter<byte>();
+
+        writer.AddNonterminal(default, NonterminalAttributes.None, 0);
+        writer.AddNonterminal(default, NonterminalAttributes.None, 1);
+        writer.AddNonterminal(default, NonterminalAttributes.None, 0);
+        writer.AddNonterminal(default, NonterminalAttributes.None, 0);
+        writer.AddNonterminal(default, NonterminalAttributes.None, 2);
+        writer.AddNonterminal(default, NonterminalAttributes.None, 0);
+        writer.AddNonterminal(default, NonterminalAttributes.None, 0);
+        writer.AddNonterminal(default, NonterminalAttributes.None, 0);
+        writer.AddNonterminal(default, NonterminalAttributes.None, 1);
+        writer.AddNonterminal(default, NonterminalAttributes.None, 0);
+        writer.AddProduction(0);
+        writer.AddProduction(0);
+        writer.AddProduction(0);
+        writer.AddProduction(0);
+        writer.WriteTo(buffer, 0);
+        var bytes = buffer.ToArray();
+
+        var tables = new GrammarTables(bytes, new(0, bytes.Length), out _);
+        tables.ValidateContent(bytes, default, default);
+    }
 }


### PR DESCRIPTION
This lets us remove the extra copies and allocations done in the previous syntax provider implementation, and simplifies logic a bit.

Some prerequisite work needed to be done to allow this, but I think it's an improvement either way.