### PR TITLE
Refactor COM# bindings to be based on `IDynamicInterfaceCastable`.

### DIFF
--- a/src/Common/ComSharp/PrecompilerInterface.Interop.cs
+++ b/src/Common/ComSharp/PrecompilerInterface.Interop.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 
 namespace ComSharp;
 
@@ -33,14 +34,21 @@ partial class PrecompilerInterfaceWrappers
         return false;
     }
 
-    public override object? CreateObject(Type targetType, object sourceObject, ComSharpVtable vtable)
+    protected override RuntimeTypeHandle GetDotNetWrapperImplementation(RuntimeTypeHandle interfaceType)
     {
-        if (targetType == typeof(IPrecompiledGrammar)) return new IPrecompiledGrammar_Wrapper(this, sourceObject, vtable);
-        if (targetType == typeof(ILogger)) return new ILogger_Wrapper(this, sourceObject, vtable);
-        if (targetType == typeof(IPrecompilerOptions)) return new IPrecompilerOptions_Wrapper(this, sourceObject, vtable);
-        if (targetType == typeof(IPrecompilerInterface)) return new IPrecompilerInterface_Wrapper(this, sourceObject, vtable);
-        return null;
+        var type = Type.GetTypeFromHandle(interfaceType);
+        if (type == typeof(IPrecompiledGrammar)) return typeof(IPrecompiledGrammar_Wrapper).TypeHandle;
+        if (type == typeof(ILogger)) return typeof(ILogger_Wrapper).TypeHandle;
+        if (type == typeof(IPrecompilerOptions)) return typeof(IPrecompilerOptions_Wrapper).TypeHandle;
+        if (type == typeof(IPrecompilerInterface)) return typeof(IPrecompilerInterface_Wrapper).TypeHandle;
+        return default;
     }
+
+    protected override DotNetWrapper CreateDotNetWrapper(object sourceObject, ComSharpVtable vtable)
+        => new Wrapper(this, sourceObject, vtable);
+
+    private sealed class Wrapper(ComSharpWrappers wrappers, object sourceObject, ComSharpVtable vtable)
+        : DotNetWrapper(wrappers, sourceObject, vtable);
 }
 
 #region COM# callable wrappers
@@ -99,47 +107,49 @@ partial class PrecompilerInterfaceWrappers
 #endregion
 
 #region .NET callable wrappers
-file sealed class IPrecompiledGrammar_Wrapper(ComSharpWrappers wrappers, object sourceObject, ComSharpVtable vtable)
-    : WrappedObject(wrappers, sourceObject, vtable), IPrecompiledGrammar
+#pragma warning disable CA2256 // All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+// We get the implementation of IDotNetWrapper from the .NET wrapper object.
+[DynamicInterfaceCastableImplementation]
+file interface IPrecompiledGrammar_Wrapper : IPrecompiledGrammar, IDotNetWrapper
 {
-    private readonly Func<object, string?> f_Key = (Func<object, string?>)vtable[1];
-    private readonly Func<object, byte[]?> f_GrammarFile = (Func<object, byte[]?>)vtable[2];
-    private readonly Func<object, int> f_InputMethodMetadataToken = (Func<object, int>)vtable[3];
-    private readonly Func<object, IReadOnlyList<(int, int)>> f_OutputMethods = (Func<object, IReadOnlyList<(int, int)>>)vtable[4];
+    string? IPrecompiledGrammar.Key =>
+        this.GetFunction<IPrecompiledGrammar, Func<object, string?>>(1)(SourceObject);
 
-    public string? Key => f_Key(SourceObject);
-    public byte[]? GrammarFile => f_GrammarFile(SourceObject);
-    public int InputMethodMetadataToken => f_InputMethodMetadataToken(SourceObject);
-    public IReadOnlyList<(int MetadataToken, OutputType Type)> OutputMethods =>
-        CollectionMarshaller.Marshal(f_OutputMethods(SourceObject), x => (x.Item1, (OutputType)x.Item2));
+    byte[]? IPrecompiledGrammar.GrammarFile =>
+        this.GetFunction<IPrecompiledGrammar, Func<object, byte[]?>>(2)(SourceObject);
+
+    int IPrecompiledGrammar.InputMethodMetadataToken =>
+        this.GetFunction<IPrecompiledGrammar, Func<object, int>>(3)(SourceObject);
+
+    IReadOnlyList<(int MetadataToken, OutputType Type)> IPrecompiledGrammar.OutputMethods =>
+        CollectionMarshaller.Marshal(this.GetFunction<IPrecompiledGrammar, Func<object, IReadOnlyList<(int, int)>>>(4)(SourceObject), x => (x.Item1, (OutputType)x.Item2));
 }
 
-file sealed class ILogger_Wrapper(ComSharpWrappers wrappers, object sourceObject, ComSharpVtable vtable) :
-    WrappedObject(wrappers, sourceObject, vtable), ILogger
+[DynamicInterfaceCastableImplementation]
+file interface ILogger_Wrapper : ILogger, IDotNetWrapper
 {
-    private readonly Func<object, int> f_LogLevel = (Func<object, int>)vtable[1];
-    private readonly Action<object, int, object, string?> f_Log = (Action<object, int, object, string?>)vtable[2];
+    DiagnosticSeverity ILogger.LogLevel =>
+        (DiagnosticSeverity)this.GetFunction<ILogger, Func<object, int>>(1)(SourceObject);
 
-    public DiagnosticSeverity LogLevel => (DiagnosticSeverity)f_LogLevel(SourceObject);
-    public void Log(DiagnosticSeverity severity, object message, string? code) => f_Log(SourceObject, (int)severity, message, code);
+    void ILogger.Log(DiagnosticSeverity severity, object message, string? code) =>
+        this.GetFunction<ILogger, Action<object, int, object, string?>>(2)(SourceObject, (int)severity, message, code);
 }
 
-file sealed class IPrecompilerOptions_Wrapper(ComSharpWrappers wrappers, object sourceObject, ComSharpVtable vtable)
-    : WrappedObject(wrappers, sourceObject, vtable), IPrecompilerOptions
+[DynamicInterfaceCastableImplementation]
+file interface IPrecompilerOptions_Wrapper : IPrecompilerOptions, IDotNetWrapper
 {
-    private readonly Func<object, CancellationToken> f_CancellationToken = (Func<object, CancellationToken>)vtable[1];
-    private readonly Func<object, ComSharpObject> f_Logger = (Func<object, ComSharpObject>)vtable[2];
+    CancellationToken IPrecompilerOptions.CancellationToken =>
+        this.GetFunction<IPrecompilerOptions, Func<object, CancellationToken>>(1)(SourceObject);
 
-    public CancellationToken CancellationToken => f_CancellationToken(SourceObject);
-    public ILogger Logger => Wrappers.Unmarshal<ILogger>(f_Logger(SourceObject));
+    ILogger IPrecompilerOptions.Logger =>
+        Wrappers.Unmarshal<ILogger>(this.GetFunction<IPrecompilerOptions, Func<object, ComSharpObject>>(2)(SourceObject));
 }
 
-file sealed class IPrecompilerInterface_Wrapper(ComSharpWrappers wrappers, object sourceObject, ComSharpVtable vtable)
-    : WrappedObject(wrappers, sourceObject, vtable), IPrecompilerInterface
+[DynamicInterfaceCastableImplementation]
+file interface IPrecompilerInterface_Wrapper : IPrecompilerInterface, IDotNetWrapper
 {
-    private readonly Func<object, IReadOnlyCollection<Type>, ComSharpObject, IEnumerable<ComSharpObject>> f_DiscoverAndPrecompile = (Func<object, IReadOnlyCollection<Type>, ComSharpObject, IEnumerable<ComSharpObject>>)vtable[1];
-
-    public IEnumerable<IPrecompiledGrammar> DiscoverAndPrecompile(IReadOnlyCollection<Type> types, IPrecompilerOptions? options) =>
-        CollectionMarshaller.Marshal(f_DiscoverAndPrecompile(SourceObject, types, Wrappers.Marshal(options)), Wrappers.Unmarshal<IPrecompiledGrammar>);
+    IEnumerable<IPrecompiledGrammar> IPrecompilerInterface.DiscoverAndPrecompile(IReadOnlyCollection<Type> types, IPrecompilerOptions? options) =>
+        CollectionMarshaller.Marshal(this.GetFunction<IPrecompilerInterface, Func<object, IReadOnlyCollection<Type>, ComSharpObject, IEnumerable<ComSharpObject>>>(1)(SourceObject, types, Wrappers.Marshal(options)), Wrappers.Unmarshal<IPrecompiledGrammar>);
 }
+#pragma warning restore CA2256 // All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
 #endregion

--- a/src/Common/ComSharp/Redist/CoreTypes.cs
+++ b/src/Common/ComSharp/Redist/CoreTypes.cs
@@ -8,6 +8,8 @@ global using ComSharpObject = (object? SourceObject, System.Collections.Generic.
 
 using Microsoft.CodeAnalysis;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Diagnostics;
 
 namespace ComSharp;
 
@@ -19,7 +21,7 @@ internal abstract class ComSharpWrappers
 {
     private readonly ComSharpVtable _defaultVtable;
 
-    public ComSharpVtable? QueryInterface(object? source, Guid iid)
+    protected ComSharpVtable? QueryInterface(object? source, Guid iid)
     {
         if (source is null)
         {
@@ -43,10 +45,12 @@ internal abstract class ComSharpWrappers
 
     protected abstract bool TryGetInterfaceInfo(Guid iid, [NotNullWhen(true)] out Type? type, [NotNullWhen(true)] out ComSharpVtable? vtable);
 
-    public abstract object? CreateObject(Type targetType, object sourceObject, ComSharpVtable vtable);
+    protected abstract RuntimeTypeHandle GetDotNetWrapperImplementation(RuntimeTypeHandle interfaceType);
 
-// Because COM# objects are value tuples, they can't work with nullable reference types.
-// In order to avoid !s in marshalling code, mark method signatures as nullable-oblivious.
+    protected abstract DotNetWrapper CreateDotNetWrapper(object sourceObject, ComSharpVtable vtable);
+
+    // Because COM# objects are value tuples, they can't work with nullable reference types.
+    // In order to avoid !s in marshalling code, mark method signatures as nullable-oblivious.
 #nullable disable annotations
 
     /// <summary>
@@ -62,8 +66,8 @@ internal abstract class ComSharpWrappers
         {
             case null:
                 return (null, _defaultVtable);
-            case WrappedObject wrapped:
-                return (wrapped.SourceObject, wrapped.Vtable);
+            case DotNetWrapper wrapped:
+                return (wrapped.SourceObject, wrapped.QueryInterface(typeof(T).GUID)!);
         }
         if (!TryGetInterfaceInfo(typeof(T).GUID, out _, out var vtable))
         {
@@ -86,7 +90,7 @@ internal abstract class ComSharpWrappers
             case null: return null;
             case T x: return x;
         }
-        if (CreateObject(typeof(T), obj.SourceObject, obj.Vtable) is not T wrapped)
+        if (CreateDotNetWrapper(obj.SourceObject, obj.Vtable) is not T wrapped)
         {
             throw new InvalidOperationException("Cannot create .NET wrapper for this interface");
         }
@@ -110,11 +114,7 @@ internal abstract class ComSharpWrappers
     /// </remarks>
     public ComSharpObject ConvertToComSharp(object? source)
     {
-        if (source is WrappedObject wrapped)
-        {
-            return (wrapped.SourceObject, wrapped.Vtable);
-        }
-        return (source, _defaultVtable);
+        return ((source as DotNetWrapper)?.SourceObject ?? source, _defaultVtable);
     }
 
     /// <summary>
@@ -122,9 +122,8 @@ internal abstract class ComSharpWrappers
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The returned object supports being casted through methods in the <see cref="WrappedObjectExtensions"/>
-    /// class, to any interface known to this <see cref="ComSharpWrappers"/> instance, that is implemented by
-    /// <paramref name="obj"/>.
+    /// The returned object supports being casted to any interface known to this <see cref="ComSharpWrappers"/>
+    /// instance, that is implemented by <paramref name="obj"/>.
     /// </para>
     /// <para>
     /// This method is the "entry point" from the COM# to the .NET type systems. It is intended to be called
@@ -137,67 +136,69 @@ internal abstract class ComSharpWrappers
         {
             return null;
         }
-        return new WrappedObject(this, obj.SourceObject, obj.Vtable);
+        return CreateDotNetWrapper(obj.SourceObject, obj.Vtable);
+    }
+
+    // This is an abstract class. Each ComSharpWrappers universe will return its own subclass from
+    // CreateDotNetWrapper, in order to avoid interference in the runtime's IDIC cache across universes.
+    protected abstract class DotNetWrapper(ComSharpWrappers wrappers, object sourceObject, ComSharpVtable vtable) : IDynamicInterfaceCastable, IDotNetWrapper
+    {
+        public ComSharpWrappers Wrappers { get; } = wrappers;
+
+        public object SourceObject { get; } = sourceObject;
+
+        private readonly Func<object?, Guid, ComSharpVtable?> _queryInterfaceFunc = (Func<object?, Guid, ComSharpVtable?>)vtable[0];
+
+        public ComSharpVtable? QueryInterface(Guid iid) => _queryInterfaceFunc(SourceObject, iid);
+
+        bool IDynamicInterfaceCastable.IsInterfaceImplemented(RuntimeTypeHandle interfaceType, bool throwIfNotImplemented)
+        {
+            var guid = Type.GetTypeFromHandle(interfaceType)!.GUID;
+            bool isImplemented = QueryInterface(guid) is not null;
+            if (!isImplemented && throwIfNotImplemented)
+            {
+                ThrowIfNotImplemented();
+            }
+            return isImplemented;
+
+            [StackTraceHidden]
+            static void ThrowIfNotImplemented()
+            {
+                throw new InvalidCastException();
+            }
+        }
+
+        RuntimeTypeHandle IDynamicInterfaceCastable.GetInterfaceImplementation(RuntimeTypeHandle interfaceType) =>
+            Wrappers.GetDotNetWrapperImplementation(interfaceType);
+
+        public override bool Equals(object? obj) => Equals(SourceObject, (obj as DotNetWrapper)?.SourceObject ?? obj);
+
+        public override int GetHashCode() => SourceObject.GetHashCode();
+
+        public override string? ToString() => SourceObject.ToString();
     }
 }
 
 [Embedded]
-internal class WrappedObject(ComSharpWrappers wrappers, object sourceObject, ComSharpVtable vtable)
+internal interface IDotNetWrapper
 {
-    protected ComSharpWrappers Wrappers { get; } = wrappers;
+    ComSharpWrappers Wrappers { get; }
 
-    public object SourceObject { get; } = sourceObject;
+    object SourceObject { get; }
 
-    public ComSharpVtable Vtable { get; } = vtable;
-
-    private ComSharpVtable? QueryInterface(Guid iid) => ((Func<object?, Guid, ComSharpVtable?>)Vtable[0])(SourceObject, iid);
-
-    public bool Is<T>([NotNullWhen(true)] out T? result) where T : class
-    {
-        result = null;
-        if (QueryInterface(typeof(T).GUID) is not { } newVtable)
-        {
-            return false;
-        }
-        if (Wrappers.CreateObject(typeof(T), SourceObject, newVtable) is not T x)
-        {
-            return false;
-        }
-        result = x;
-        return result is not null;
-    }
-
-    public override bool Equals(object? obj) => obj is WrappedObject other && Equals(SourceObject, other.SourceObject);
-
-    public override int GetHashCode() => SourceObject.GetHashCode();
-
-    public override string? ToString() => SourceObject.ToString();
+    ComSharpVtable? QueryInterface(Guid iid);
 }
 
 [Embedded]
-internal static class WrappedObjectExtensions
+internal static class DotNetWrapperExtensions
 {
-    public static bool IsComSharp<T>([NotNullWhen(true)] this object? obj, [NotNullWhen(true)] out T? result) where T : class
+    extension(IDotNetWrapper provider)
     {
-        result = null;
-        if (obj is not WrappedObject wrapped)
+        public TDelegate GetFunction<TInterface, TDelegate>(int idx)
+            where TInterface : class
+            where TDelegate : Delegate
         {
-            return false;
+            return (TDelegate)provider.QueryInterface(typeof(TInterface).GUID)![idx];
         }
-        return wrapped.Is(out result);
-    }
-
-    [return: NotNullIfNotNull(nameof(obj))]
-    public static T? AsComSharp<T>(this object? obj) where T : class
-    {
-        if (obj is null)
-        {
-            return null;
-        }
-        if (!obj.IsComSharp(out T? result))
-        {
-            throw new InvalidCastException();
-        }
-        return result;
     }
 }

--- a/src/Farkle.Tools.Precompiler/PrecompilerHost.cs
+++ b/src/Farkle.Tools.Precompiler/PrecompilerHost.cs
@@ -81,7 +81,7 @@ public sealed class PrecompilerHost
             return null;
         }
         if (precompilerInterfaceFactory.Invoke(null, null) is not ComSharpObject intfComSharp
-            || !PrecompilerInterfaceWrappers.Instance.ConvertToDotNet(intfComSharp).IsComSharp(out IPrecompilerInterface? intf))
+            || PrecompilerInterfaceWrappers.Instance.ConvertToDotNet(intfComSharp) is not IPrecompilerInterface intf)
         {
             Log?.IncompatiblePrecompilerInterface();
             return null;

--- a/tests/Farkle.Tests.CSharp/PrecompilerInterfaceTests.cs
+++ b/tests/Farkle.Tests.CSharp/PrecompilerInterfaceTests.cs
@@ -19,7 +19,7 @@ internal class PrecompilerInterfaceTests
     public void Setup()
     {
         var intf = PrecompilerEntryPoints.GetPrecompilerInterface();
-        _precompilerInterface = PrecompilerInterfaceWrappers.Instance.ConvertToDotNet(intf).AsComSharp<IPrecompilerInterface>()!;
+        _precompilerInterface = (IPrecompilerInterface)PrecompilerInterfaceWrappers.Instance.ConvertToDotNet(intf)!;
         Assert.That(_precompilerInterface, Is.Not.Null);
     }
 


### PR DESCRIPTION
We can do this now that we target only modern .NET. This change does not require bumping the precompiler interface.